### PR TITLE
Add support for pattern matmul+add+relu/sigmoid.

### DIFF
--- a/tests/ap/op_compute_translator_util.py
+++ b/tests/ap/op_compute_translator_util.py
@@ -108,6 +108,67 @@ class PdOpDataCodeGen:
     )
 
 
+class PdOpFullCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    value = self.op_property.attributes.value.match(a_f64=lambda x:x)
+    out = self.get_out_cg_val(0)
+    mut_lir_code_gen_ctx.let(out, f"{value}")
+    return [out]
+
+  def get_out_cg_val(self, i):
+    return code_gen_value_util.CodeGenValue(
+      self.output_properties[i].type,
+      f"op{self.op_property.op_index}_out{i}"
+    )
+
+
+class PdOpCastCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+    self.dtype2type_name = OrderedDict(
+        [
+            [DataType.float,   "float"],
+            [DataType.float16,  "half"],
+            [DataType.int32,     "int"],
+            [DataType.int64, "int64_t"],
+        ]
+    )
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    dtype = self.op_property.attributes.dtype.match(a_dtype=lambda x:x)
+    dtype_name = self.dtype2type_name[dtype]
+    out = self.get_out_cg_val(0)
+    mut_lir_code_gen_ctx.let(out, f"static_cast<{dtype_name}>({inputs[0].var_name})")
+    return [out]
+
+  def get_out_cg_val(self, i):
+    return code_gen_value_util.CodeGenValue(
+      self.output_properties[i].type,
+      f"op{self.op_property.op_index}_out{i}"
+    )
+
+
 class PdOpExpCodeGen:
   def __init__(self,
                op_property,
@@ -149,6 +210,37 @@ class PdOpReluCodeGen:
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
     out = self.get_out_cg_val(0)
     mut_lir_code_gen_ctx.let(out, f"({inputs[0].var_name} > 0 ? {inputs[0].var_name} : 0) ")
+    return [out]
+
+  def get_out_cg_val(self, i):
+    return code_gen_value_util.CodeGenValue(
+      self.output_properties[i].type,
+      f"op{self.op_property.op_index}_out{i}"
+    )
+
+
+class CinnOpScaleCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    scale = self.op_property.attributes.scale.match(a_f32=lambda x:x)
+    bias = self.op_property.attributes.bias.match(a_f32=lambda x:x)
+    bias_after_scale = self.op_property.attributes.bias_after_scale.match(a_bool=lambda x:x)
+    in_name = inputs[0].var_name
+    true_str = f"{scale} * {in_name} + {bias}"
+    false_str = f"{scale} * ({in_name} + {bias})"
+    out = self.get_out_cg_val(0)
+    mut_lir_code_gen_ctx.let(out, true_str if bias_after_scale else false_str)
     return [out]
 
   def get_out_cg_val(self, i):
@@ -202,7 +294,7 @@ class PdOpAddCodeGen:
     a = inputs[0]
     b = inputs[1]
     out = self.get_out_cg_val(0)
-    mut_lir_code_gen_ctx.let(out, f"({a.var_name} + {b.var_name})")
+    mut_lir_code_gen_ctx.let(out, f"{a.var_name} + {b.var_name}")
     return [out]
 
   def get_out_cg_val(self, i):
@@ -229,7 +321,61 @@ class PdOpMultiplyCodeGen:
     a = inputs[0]
     b = inputs[1]
     out = self.get_out_cg_val(0)
-    mut_lir_code_gen_ctx.let(out, f"({a.var_name} * {b.var_name})")
+    mut_lir_code_gen_ctx.let(out, f"{a.var_name} * {b.var_name}")
+    return [out]
+
+  def get_out_cg_val(self, i):
+    return code_gen_value_util.CodeGenValue(
+      self.output_properties[i].type,
+      f"op{self.op_property.op_index}_out{i}"
+    )
+
+
+class PdOpDivideCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    a = inputs[0]
+    b = inputs[1]
+    out = self.get_out_cg_val(0)
+    mut_lir_code_gen_ctx.let(out, f"{a.var_name} / {b.var_name}")
+    return [out]
+
+  def get_out_cg_val(self, i):
+    return code_gen_value_util.CodeGenValue(
+      self.output_properties[i].type,
+      f"op{self.op_property.op_index}_out{i}"
+    )
+
+
+class PdOpMaximumCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    a = inputs[0]
+    b = inputs[1]
+    out = self.get_out_cg_val(0)
+    mut_lir_code_gen_ctx.let(out, f"(({a.var_name} >= {b.var_name}) ? ({a.var_name}) : ({b.var_name}))")
     return [out]
 
   def get_out_cg_val(self, i):
@@ -303,11 +449,16 @@ class OpComputeTranslatorFactory:
       ["ap_op.store_to_register",   ApOpStoreToRegisterCodeGen],
       ["ap_op.load_from_global",    ApOpLoadFromGlobalCodeGen],
       ["pd_op.data",                PdOpDataCodeGen],
+      ["pd_op.full",                PdOpFullCodeGen],
+      ["pd_op.cast",                PdOpCastCodeGen],
       ["pd_op.exp",                 PdOpExpCodeGen],
       ["pd_op.relu",                PdOpReluCodeGen],
+      ["cinn_op.scale",             CinnOpScaleCodeGen],
       ["pd_op.subtract",            PdOpSubstractCodeGen],
       ["pd_op.add",                 PdOpAddCodeGen],
       ["pd_op.multiply",            PdOpMultiplyCodeGen],
+      ["pd_op.divide",              PdOpDivideCodeGen],
+      ["pd_op.maximum",             PdOpMaximumCodeGen],
       ["cinn_op.yield_store",       CinnOpYieldStoreCodeGen],
       ["cinn_op.broadcast",         CinnOpBroadcastCodeGen],
       ["cinn_op.generate_shape",    CinnOpGenerateShapeCodeGen]

--- a/tests/ap/op_convertion_drr_pass.py
+++ b/tests/ap/op_convertion_drr_pass.py
@@ -1,10 +1,44 @@
 import access_topo_drr
 
+@access_topo_drr.register_drr_pass("pd_op_cast", tag="default")
+class PdOpCastAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.exp_op = o.ap_native_op("pd_op.cast")
+    o.exp_op(
+      [t.input],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.fustion_op = o.ap_native_op("pd_op.relu")
+    o.fustion_op(
+      [t.input],
+      [t.output]
+    )
+
 @access_topo_drr.register_drr_pass("pd_op_exp", tag="default")
 class PdOpExpAccessTopoPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):
     o.exp_op = o.ap_native_op("pd_op.exp")
+    o.exp_op(
+      [t.input],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.fustion_op = o.ap_native_op("pd_op.relu")
+    o.fustion_op(
+      [t.input],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("cinn_op_scale", tag="default")
+class CinnOpScaleAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.exp_op = o.ap_native_op("cinn_op.scale")
     o.exp_op(
       [t.input],
       [t.output]
@@ -65,5 +99,83 @@ class PdOpSubtractAccessTopoPass(access_topo_drr.DrrPass):
     o.result_op = o.ap_native_op("pd_op.add")
     o.result_op(
       [t.input0, t.input1],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("pd_op_divide", tag="default")
+class PdOpDivideAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.source_op = o.ap_native_op("pd_op.divide")
+    o.source_op(
+      [t.input0, t.input1],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.add")
+    o.result_op(
+      [t.input0, t.input1],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("pd_op_maximum", tag="default")
+class PdOpMaximumAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.source_op = o.ap_native_op("pd_op.maximum")
+    o.source_op(
+      [t.input0, t.input1],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.add")
+    o.result_op(
+      [t.input0, t.input1],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("pd_op_left_full_add", tag="default")
+class PdOpLeftFullAddAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.full_op = o.ap_native_op("pd_op.full")
+    o.full_op(
+      [],
+      [t.intermediate]
+    )
+    o.source_op = o.ap_native_op("pd_op.add")
+    o.source_op(
+      [t.intermediate, t.input],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
+      [t.input],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("pd_op_right_full_add", tag="default")
+class PdOpRightFullAddAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.full_op = o.ap_native_op("pd_op.full")
+    o.full_op(
+      [],
+      [t.intermediate]
+    )
+    o.source_op = o.ap_native_op("pd_op.add")
+    o.source_op(
+      [t.input, t.intermediate],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
+      [t.input],
       [t.output]
     )

--- a/tests/ap/paddle-tests/test_matmul_binary.py
+++ b/tests/ap/paddle-tests/test_matmul_binary.py
@@ -64,7 +64,7 @@ class TestAPMatmulBinary(unittest.TestCase):
         self.b = paddle.randn(self.b_shape, dtype=self.dtype)
         self.b.stop_gradient = False
 
-    def eval_symbolic(self, use_cinn, profile, backward=False):
+    def eval_symbolic(self, use_cinn, profile):
         net = CINNSubGraphNet()
         input_spec = [
             InputSpec(shape=self.x_shape, dtype=self.dtype),

--- a/tests/ap/paddle-tests/test_matmul_binary.py
+++ b/tests/ap/paddle-tests/test_matmul_binary.py
@@ -27,7 +27,7 @@ from paddle.static import InputSpec
 
 def trivial_matrix_binary(x, y, b):
     out = paddle.matmul(x, y)
-    return out + b
+    return paddle.nn.functional.relu(out + b)
 
 
 class CINNSubGraphNet(paddle.nn.Layer):
@@ -64,7 +64,7 @@ class TestAPMatmulBinary(unittest.TestCase):
         self.b = paddle.randn(self.b_shape, dtype=self.dtype)
         self.b.stop_gradient = False
 
-    def eval_symbolic(self, use_cinn, profile):
+    def eval_symbolic(self, use_cinn, profile, backward=False):
         net = CINNSubGraphNet()
         input_spec = [
             InputSpec(shape=self.x_shape, dtype=self.dtype),

--- a/tests/ap/test_matmul_binary.sh
+++ b/tests/ap/test_matmul_binary.sh
@@ -1,2 +1,6 @@
-sh make_axpr.sh
-NVIDIA_TF32_OVERRIDE=0 FLAGS_enable_ap=1 AP_WORKSPACE_DIR=$(pwd)/ap_workspace AP_PATH=$(pwd)/ FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 FLAGS_cinn_bucket_compile=True FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True FLAGS_pir_apply_shape_optimization_pass=1 FLAGS_group_schedule_tiling_first=1 FLAGS_cinn_new_group_scheduler=1 python3.9 $(pwd)/paddle-tests/test_matmul_binary.py
+export CUDA_VISIBLE_DEVICES="0"
+export NVIDIA_TF32_OVERRIDE=0
+
+sh make_axpr.sh test_matmul_binary
+
+FLAGS_enable_ap=1 AP_WORKSPACE_DIR=$(pwd)/ap_workspace AP_PATH=$(pwd)/ FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 FLAGS_cinn_bucket_compile=True FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True FLAGS_pir_apply_shape_optimization_pass=1 FLAGS_group_schedule_tiling_first=1 FLAGS_cinn_new_group_scheduler=1 python3.9 $(pwd)/paddle-tests/test_matmul_binary.py


### PR DESCRIPTION
为支持relu、sigmoid算子生成：
- OP访存拓扑同胚变换Pass，包括：
  - `cast` -> `relu`
  - `scale` -> `relu`
  - `divide` -> `add`
  - `maximum` -> `add`
  - `add(full, x)` -> `relu`
  - `add(x, full)` -> `relu`
- OP的代码生成器
  - `pd_op.full`
  - `pd_op.cast`
  - `cinn_op.scale`
  - `pd_op.divide`
  - `pd_op.maximum`

relu算子被拆解后子图结构如下：
```python
    (%5) = "pd_op.full" () {dtype:float16,place:Place(undefined:0),shape:[4,65536,32],stop_gradient:[true],value:0} : () -> tensor<4x65536x32xf16>
    (%6) = "pd_op.maximum" (%4, %5) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
```


`matmul+add+relu`子图生成的EpilogueFunctor代码如下：
```python
template <typename T>
struct VariadicEpilogueFunctor {
  struct Arguments {
    const half* in_ptr_0;
  };  

  // Note: need to support vectorized operation
  __forceinline__ __host__ __device__
  T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
    T out;
    float op1_out0 = static_cast<float>(args.in_ptr_0[(coord.column)]);
    float op4_out0 = static_cast<float>(x + op1_out0);
    float op5_out0 = static_cast<float>(0.000000);
    float op6_out0 = static_cast<float>(((op4_out0 >= op5_out0) ? (op4_out0) : (op5_out0)));
    out = op6_out0;
    return out;
  }
};
```

sigmoid被拆解后子图结构如下：
```python
    (%5) = "pd_op.cast" (%4) {dtype:float32,stop_gradient:[false]} : (tensor<4x65536x32xf16>) -> tensor<4x65536x32xf32>
    (%6) = "cinn_op.scale" (%5) {bias:0,bias_after_scale:true,scale:-1,stop_gradient:[false]} : (tensor<4x65536x32xf32>) -> tensor<4x65536x32xf32>
    (%7) = "pd_op.exp" (%6) {stop_gradient:[false]} : (tensor<4x65536x32xf32>) -> tensor<4x65536x32xf32>
    (%8) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[4,65536,32],stop_gradient:[true],value:1} : () -> tensor<4x65536x32xf32>
    (%9) = "pd_op.add" (%8, %7) {stop_gradient:[false]} : (tensor<4x65536x32xf32>, tensor<4x65536x32xf32>) -> tensor<4x65536x32xf32>
    (%10) = "pd_op.full" () {dtype:float32,place:Place(cpu),shape:[4,65536,32],stop_gradient:[true],value:1} : () -> tensor<4x65536x32xf32>
    (%11) = "pd_op.divide" (%10, %9) {stop_gradient:[false]} : (tensor<4x65536x32xf32>, tensor<4x65536x32xf32>) -> tensor<4x65536x32xf32>
    (%12) = "pd_op.cast" (%11) {dtype:float16,stop_gradient:[false]} : (tensor<4x65536x32xf32>) -> tensor<4x65536x32xf16>
```

`matmul+add+sigmoid`子图生成的EpilogueFunctor代码如下：
```python
template <typename T>
struct VariadicEpilogueFunctor {
  struct Arguments {
    const half* in_ptr_0;
  };  

  // Note: need to support vectorized operation
  __forceinline__ __host__ __device__
  T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
    T out;
    float op1_out0 = static_cast<float>(args.in_ptr_0[(coord.column)]);
    float op4_out0 = static_cast<float>(x + op1_out0);
    float op5_out0 = (static_cast<float>(op4_out0));
    float op6_out0 = (-1.000000 * op5_out0 + 0.000000);
    float op7_out0 = (expf(op6_out0));
    float op8_out0 = (1.000000);
    float op9_out0 = (op8_out0 + op7_out0);
    float op10_out0 = (1.000000);
    float op11_out0 = (op10_out0 / op9_out0);
    float op12_out0 = static_cast<float>(static_cast<half>(op11_out0));
    out = op12_out0;
    return out;
  }
};
```