### PR TITLE
[ap] support mm-add-gelu

### DIFF
--- a/tests/ap/op_compute_translator_util.py
+++ b/tests/ap/op_compute_translator_util.py
@@ -218,6 +218,81 @@ class PdOpReluCodeGen:
       f"op{self.op_property.op_index}_out{i}"
     )
 
+class PdOpErfCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    var_name = inputs[0].var_name
+    out = self.get_out_cg_val(0)
+    mut_lir_code_gen_ctx.let(out, f"erf({var_name})")
+    return [out]
+
+  def get_out_cg_val(self, i):
+    return code_gen_value_util.CodeGenValue(
+      self.output_properties[i].type,
+      f"op{self.op_property.op_index}_out{i}"
+    )
+
+class PdOpElementwisePowCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    exponent = inputs[1].var_name
+    var_name = inputs[0].var_name
+    out = self.get_out_cg_val(0)
+    mut_lir_code_gen_ctx.let(out, f"pow({var_name},{exponent})")
+    return [out]
+
+  def get_out_cg_val(self, i):
+    return code_gen_value_util.CodeGenValue(
+      self.output_properties[i].type,
+      f"op{self.op_property.op_index}_out{i}"
+    )
+
+class PdOpTanhCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    var_name = inputs[0].var_name
+    out = self.get_out_cg_val(0)
+    mut_lir_code_gen_ctx.let(out, f"tanh({var_name})")
+    return [out]
+
+  def get_out_cg_val(self, i):
+    return code_gen_value_util.CodeGenValue(
+      self.output_properties[i].type,
+      f"op{self.op_property.op_index}_out{i}"
+    )
 
 class CinnOpScaleCodeGen:
   def __init__(self,
@@ -453,6 +528,9 @@ class OpComputeTranslatorFactory:
       ["pd_op.cast",                PdOpCastCodeGen],
       ["pd_op.exp",                 PdOpExpCodeGen],
       ["pd_op.relu",                PdOpReluCodeGen],
+      ["pd_op.tanh",                PdOpTanhCodeGen],
+      ["pd_op.erf",                 PdOpErfCodeGen],
+      ["pd_op.elementwise_pow",     PdOpElementwisePowCodeGen],
       ["cinn_op.scale",             CinnOpScaleCodeGen],
       ["pd_op.subtract",            PdOpSubstractCodeGen],
       ["pd_op.add",                 PdOpAddCodeGen],

--- a/tests/ap/op_convertion_drr_pass.py
+++ b/tests/ap/op_convertion_drr_pass.py
@@ -17,6 +17,57 @@ class PdOpCastAccessTopoPass(access_topo_drr.DrrPass):
       [t.output]
     )
 
+@access_topo_drr.register_drr_pass("pd_op_tanh", tag="default")
+class PdOpTanhAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.exp_op = o.ap_native_op("pd_op.tanh")
+    o.exp_op(
+      [t.input],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.fustion_op = o.ap_native_op("pd_op.relu")
+    o.fustion_op(
+      [t.input],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("pd_op_erf", tag="default")
+class PdOpErfAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.exp_op = o.ap_native_op("pd_op.erf")
+    o.exp_op(
+      [t.input],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.fustion_op = o.ap_native_op("pd_op.relu")
+    o.fustion_op(
+      [t.input],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("pd_op_elementwise_pow", tag="default")
+class PdOpElementwisePowAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.source_op = o.ap_native_op("pd_op.elementwise_pow")
+    o.source_op(
+      [t.input0, t.input1],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.add")
+    o.result_op(
+      [t.input0, t.input1],
+      [t.output]
+    )
+
 @access_topo_drr.register_drr_pass("pd_op_exp", tag="default")
 class PdOpExpAccessTopoPass(access_topo_drr.DrrPass):
 
@@ -115,6 +166,23 @@ class PdOpDivideAccessTopoPass(access_topo_drr.DrrPass):
   def result_pattern(self, o, t):
     o.result_op = o.ap_native_op("pd_op.add")
     o.result_op(
+      [t.input0, t.input1],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("pd_op_multiply", tag="default")
+class PdOpMultiplyAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.source_op = o.ap_native_op("pd_op.multiply")
+    o.source_op(
+      [t.input0, t.input1],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.fustion_op = o.ap_native_op("pd_op.add")
+    o.fustion_op(
       [t.input0, t.input1],
       [t.output]
     )

--- a/tests/ap/paddle-tests/test_matmul_binary.py
+++ b/tests/ap/paddle-tests/test_matmul_binary.py
@@ -29,18 +29,20 @@ def trivial_matrix_binary(x, y, b):
     out = paddle.matmul(x, y)
     return paddle.nn.functional.relu(out + b)
 
+def trivial_matrix_binary_gelu_true(x, y, b):
+    out = paddle.matmul(x, y)
+    return paddle.nn.functional.gelu(out + b, True)
 
 class CINNSubGraphNet(paddle.nn.Layer):
-    def __init__(self):
+    def __init__(self, fn):
         super().__init__()
-        self.fn = trivial_matrix_binary
+        self.fn = fn
 
     def forward(self, x, y, b):
         out = self.fn(x, y, b)
         return out
 
-
-class TestAPMatmulBinary(unittest.TestCase):
+class TestAPMatmulBinaryTriangleShape(unittest.TestCase):
     """
     Test Pir API + @to_static + CINN.
     """
@@ -65,7 +67,7 @@ class TestAPMatmulBinary(unittest.TestCase):
         self.b.stop_gradient = False
 
     def eval_symbolic(self, use_cinn, profile):
-        net = CINNSubGraphNet()
+        net = CINNSubGraphNet(trivial_matrix_binary_gelu_true)
         input_spec = [
             InputSpec(shape=self.x_shape, dtype=self.dtype),
             InputSpec(shape=self.y_shape, dtype=self.dtype),

--- a/tests/ap/paddle-tests/utils.py
+++ b/tests/ap/paddle-tests/utils.py
@@ -50,7 +50,7 @@ def check_result(dtype, out_1, out_2, check_equal=False):
         f"-- max difference     : {np.max(diff)}, {out_1_flatten[max_atol_idx]} vs {out_2_flatten[max_atol_idx]}"
     )
 
-    relative_error = np.abs(diff / out_2_flatten)
+    relative_error = np.abs(diff / (out_2_flatten + 1e-8))
     max_rtol_idx = np.nanargmax(relative_error)
     print(
         f"-- max relative error : {np.nanmax(relative_error)}, {out_1_flatten[max_rtol_idx]} vs {out_2_flatten[max_rtol_idx]}"

--- a/tests/ap/topo_drr_pass.py
+++ b/tests/ap/topo_drr_pass.py
@@ -533,3 +533,21 @@ class LeftDownSpiderUpSpiderAccessTopoPass(access_topo_drr.DrrPass):
       [t.input0, t.input1],
       []
     )
+
+@access_topo_drr.register_drr_pass("triangle_left_down_spider_up_spider", tag="default")
+class TriangleLeftDownSpiderUpSpiderAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.expand = o.ap_native_op("ap_op.down_spider")
+    o.expand(
+      [t.input0],
+      [t.output0]
+    )
+    o.up_spider = o.ap_native_op("ap_op.up_spider")
+    o.up_spider(
+      [t.input0, t.output0],
+      []
+    )
+
+  def result_pattern(self, o, t):
+    pass


### PR DESCRIPTION
为支持 Gelu 算子生成：

- OP访存拓扑同胚变换Pass，包括：
  - `elementwise_pow` -> `relu`
  - `tanh` -> `relu`
  - `erf` -> `relu`
  - `multiply` -> `add`
  - `multiply(full, x)` -> `relu`
  - `multiply(x, full)` -> `relu`
- OP的代码生成器
  - `pd_op.elementwise_pow`
  - `pd_op.tanh`
  - `pd_op.erf`
- TOPO_DRR_PASS 添加规则
  - triangle_downspider_upspider -> {}
    - upspider(data, downspider(data)) -> {} // 增加mat_binary对于三角形（纺锤体）计算图的支持

Gelu(x)算子被拆解后子图结构如下：

```
(%8) = "pd_op.elementwise_pow" (%6, %7) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%9) = "pd_op.full" () {dtype:float16,place:Place(undefined:0),shape:[4,65536,32],stop_gradient:[true],value:0.044715} : () -> tensor<4x65536x32xf16>
        (%10) = "pd_op.multiply" (%8, %9) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%11) = "pd_op.add" (%6, %10) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%12) = "pd_op.full" () {dtype:float16,place:Place(undefined:0),shape:[4,65536,32],stop_gradient:[true],value:0.797885} : () -> tensor<4x65536x32xf16>
        (%13) = "pd_op.multiply" (%12, %11) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%14) = "pd_op.tanh" (%13) {stop_gradient:[false]} : (tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%15) = "pd_op.full" () {dtype:float16,place:Place(undefined:0),shape:[4,65536,32],stop_gradient:[true],value:1} : () -> tensor<4x65536x32xf16>
        (%16) = "pd_op.add" (%15, %14) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%17) = "pd_op.full" () {dtype:float16,place:Place(undefined:0),shape:[4,65536,32],stop_gradient:[true],value:0.5} : () -> tensor<4x65536x32xf16>
        (%18) = "pd_op.multiply" (%6, %17) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%19) = "pd_op.multiply" (%18, %16) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
```

Gelu(x, true)算子被拆解后子图结构如下：

```
(%7) = "pd_op.full" () {dtype:float16,place:Place(undefined:0),shape:[4,65536,32],stop_gradient:[true],value:0.707107} : () -> tensor<4x65536x32xf16>
        (%8) = "pd_op.multiply" (%6, %7) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%9) = "pd_op.erf" (%8) {stop_gradient:[false]} : (tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%10) = "pd_op.full" () {dtype:float16,place:Place(undefined:0),shape:[4,65536,32],stop_gradient:[true],value:1} : () -> tensor<4x65536x32xf16>
        (%11) = "pd_op.add" (%10, %9) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%12) = "pd_op.full" () {dtype:float16,place:Place(undefined:0),shape:[4,65536,32],stop_gradient:[true],value:0.5} : () -> tensor<4x65536x32xf16>
        (%13) = "pd_op.multiply" (%6, %12) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
        (%14) = "pd_op.multiply" (%13, %11) {stop_gradient:[false]} : (tensor<4x65536x32xf16>, tensor<4x65536x32xf16>) -> tensor<4x65536x32xf16>
```



`gelu(matmul+add)`子图生成的EpilogueFunctor代码如下：

```
template <typename T>
struct VariadicEpilogueFunctor {
  struct Arguments {
    const half* in_ptr_0;
  };

  // Note: need to support vectorized operation
  __forceinline__ __host__ __device__
  T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
    T out;
    float op1_out0 = static_cast<float>(args.in_ptr_0[(coord.column)]);
    float op4_out0 = static_cast<float>(x + op1_out0);
    float op5_out0 = static_cast<float>(3.000000);
    float op6_out0 = static_cast<float>(pow(op4_out0,op5_out0));
    float op7_out0 = static_cast<float>(0.044715);
    float op8_out0 = static_cast<float>(op6_out0 * op7_out0);
    float op9_out0 = static_cast<float>(op4_out0 + op8_out0);
    float op10_out0 = static_cast<float>(0.797885);
    float op11_out0 = static_cast<float>(op10_out0 * op9_out0);
    float op12_out0 = static_cast<float>(tanh(op11_out0));
    float op13_out0 = static_cast<float>(1.000000);
    float op14_out0 = static_cast<float>(op13_out0 + op12_out0);
    float op15_out0 = static_cast<float>(0.500000);
    float op16_out0 = static_cast<float>(op4_out0 * op15_out0);
    float op17_out0 = static_cast<float>(op16_out0 * op14_out0);
    out = op17_out0;
    return out;
  }
};
```



`gelu(matmul+add, True)`子图生成的EpilogueFunctor代码如下：

```
template <typename T>
struct VariadicEpilogueFunctor {
  struct Arguments {
    const half* in_ptr_0;
  };

  // Note: need to support vectorized operation
  __forceinline__ __host__ __device__
  T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
    T out;
    float op1_out0 = static_cast<float>(args.in_ptr_0[(coord.column)]);
    float op4_out0 = static_cast<float>(x + op1_out0);
    float op5_out0 = static_cast<float>(0.707107);
    float op6_out0 = static_cast<float>(op4_out0 * op5_out0);
    float op7_out0 = static_cast<float>(erf(op6_out0));
    float op8_out0 = static_cast<float>(1.000000);
    float op9_out0 = static_cast<float>(op8_out0 + op7_out0);
    float op10_out0 = static_cast<float>(0.500000);
    float op11_out0 = static_cast<float>(op4_out0 * op10_out0);
    float op12_out0 = static_cast<float>(op11_out0 * op9_out0);
    out = op12_out0;
    return out;
  }
};
```

