### PR TITLE
Support two-subgraphs in a single net.

### DIFF
--- a/tests/ap/matmul/cutlass_matmul.cuh
+++ b/tests/ap/matmul/cutlass_matmul.cuh
@@ -38,6 +38,42 @@ static void* GetWorkspace(size_t workspace_size) {
   return workspace.get();
 }
 
+template <typename GemmFunc>
+cutlass::Status SetMaxDynamicSharedMemorySize() {
+  cudaError_t cudart_result;
+
+  // If requires more than 48KB: configure for extended, dynamic shared memory
+  if constexpr (GemmFunc::kSharedStorageSize >= (48 << 10)) {
+    cudart_result = cudaFuncSetAttribute(
+      cutlass::Kernel2<typename GemmFunc::GemmKernel>,
+      cudaFuncAttributeMaxDynamicSharedMemorySize,
+      GemmFunc::kSharedStorageSize);
+    if (cudart_result != cudaSuccess) {
+      CUTLASS_TRACE_HOST("cudaFuncSetAttribute() returned error " << cudaGetErrorString(cudart_result));
+      return cutlass::Status::kErrorInternal;
+    }
+  }
+
+#if AP_ENABLE_DEBUG
+  // Update SM occupancy member
+  int sm_occupancy = -1;
+  cudart_result = cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
+    &sm_occupancy,
+    cutlass::Kernel2<typename GemmFunc::GemmKernel>,
+    GemmFunc::GemmKernel::kThreadCount,
+    GemmFunc::kSharedStorageSize,
+    cudaOccupancyDisableCachingOverride);
+  if (cudart_result != cudaSuccess) {
+    CUTLASS_TRACE_HOST("cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags() returned error " << cudaGetErrorString(cudart_result));
+    return cutlass::Status::kErrorInternal;
+  }
+  CUTLASS_TRACE_HOST("sm_occupancy: (" << sm_occupancy_ << ") "
+      "smem_size: (" << GemmFunc::kSharedStorageSize << ") "
+      "GemmKernel::kThreadCount: (" << GemmFunc::GemmKernel::kThreadCount << ")");
+#endif
+  return cutlass::Status::kSuccess;
+}
+
 template <typename ElementT,
           typename ElementComputeT,
           bool TransposeA = false,
@@ -81,6 +117,8 @@ void CutlassMatmul(const GemmEpilogueParams& params) {
       typename GemmOperation<ElementT>::Type            // Operation performed by GEMM
   >;
 
+  CHECK_CUTLASS(SetMaxDynamicSharedMemorySize<GemmFunc>());
+
   /// Arguments
   cutlass::gemm::GemmCoord problem_size{params.m, params.n, params.k};
 
@@ -122,6 +160,9 @@ void CutlassMatmul(const GemmEpilogueParams& params) {
   // Run the GEMM
   //
   CHECK_CUTLASS(device_gemm.run(params.stream));
+#if AP_ENABLE_DEBUG
+  CHECK_CUDA(cudaStreamSynchronize(params.stream));
+#endif
 }
 
 
@@ -173,6 +214,8 @@ void CutlassMatmulAddUnary(const GemmEpilogueParams& params, const typename Unar
       typename GemmOperation<ElementT>::Type  // Operation performed by GEMM
   >;
 
+  CHECK_CUTLASS(SetMaxDynamicSharedMemorySize<GemmFunc>());
+
   /// Arguments
   cutlass::gemm::GemmCoord problem_size{params.m, params.n, params.k};
 
@@ -215,6 +258,9 @@ void CutlassMatmulAddUnary(const GemmEpilogueParams& params, const typename Unar
   // Run the GEMM
   //
   CHECK_CUTLASS(device_gemm.run(params.stream));
+#if AP_ENABLE_DEBUG
+  CHECK_CUDA(cudaStreamSynchronize(params.stream));
+#endif
 }
 
 template <typename ElementT,
@@ -279,6 +325,8 @@ void CutlassMatmulAddBroadcast(const GemmBroadcastEpilogueParams& params) {
       typename GemmOperation<ElementT>::Type  // Operation performed by GEMM
   >;
 
+  CHECK_CUTLASS(SetMaxDynamicSharedMemorySize<GemmFunc>());
+
   /// Arguments
   cutlass::gemm::GemmCoord problem_size{params.m, params.n, params.k};
 
@@ -332,6 +380,9 @@ void CutlassMatmulAddBroadcast(const GemmBroadcastEpilogueParams& params) {
   // Run the GEMM
   //
   CHECK_CUTLASS(device_gemm(params.stream));
+#if AP_ENABLE_DEBUG
+  CHECK_CUDA(cudaStreamSynchronize(params.stream));
+#endif
 }
 
 template <typename ElementT,
@@ -377,6 +428,8 @@ void CutlassMatmulAddVariadic(const GemmEpilogueParams& params, const typename V
       typename GemmOperation<ElementT>::Type  // Operation performed by GEMM
   >;
 
+  CHECK_CUTLASS(SetMaxDynamicSharedMemorySize<GemmFunc>());
+
   /// Arguments
   cutlass::gemm::GemmCoord problem_size{params.m, params.n, params.k};
 
@@ -419,6 +472,9 @@ void CutlassMatmulAddVariadic(const GemmEpilogueParams& params, const typename V
   // Run the GEMM
   //
   CHECK_CUTLASS(device_gemm(params.stream));
+#if AP_ENABLE_DEBUG
+  CHECK_CUDA(cudaStreamSynchronize(params.stream));
+#endif
 }
 
 }

--- a/tests/ap/matmul/matmul.h
+++ b/tests/ap/matmul/matmul.h
@@ -110,8 +110,8 @@ struct GemmEpilogueParams {
     }
 
 #if AP_ENABLE_DEBUG
-    std::cout << "-- [GemmEpilogueParams] m: " << m << ", n: " << n
-              << ", k: " << k << std::endl;
+    std::cout << "-- [GemmEpilogueParams] batch_count: " << batch_count
+              << ", m: " << m << ", n: " << n << ", k: " << k << std::endl;
     std::cout << "-- [GemmEpilogueParams] input: " << input << std::endl;
     std::cout << "-- [GemmEpilogueParams] weight: " << weight << std::endl;
     std::cout << "-- [GemmEpilogueParams] bias: " << bias << std::endl;

--- a/tests/ap/paddle-tests/test_two_matmul_subgraphs.py
+++ b/tests/ap/paddle-tests/test_two_matmul_subgraphs.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from os.path import dirname
+
+sys.path.append(dirname(__file__))
+
+import unittest
+
+import utils
+
+import paddle
+from paddle.static import InputSpec
+
+
+class CINNSubGraphNet(paddle.nn.Layer):
+    def __init__(self, dtype, in_features, intermedia, out_features):
+        super().__init__()
+        self.weight1 = paddle.randn([in_features, intermedia], dtype=dtype)
+        self.bias1 = paddle.randn([intermedia], dtype=dtype)
+        self.weight2 = paddle.randn([intermedia, out_features], dtype=dtype)
+        self.bias2 = paddle.randn([out_features], dtype=dtype)
+
+    def forward(self, x):
+        out = paddle.matmul(x, self.weight1) + self.bias1
+        out = paddle.nn.functional.relu(out)
+        out = paddle.matmul(out, self.weight2) + self.bias2
+        # out = paddle.nn.functional.relu(out)
+        return out
+
+
+class TestAPMatmulBinary(unittest.TestCase):
+    """
+    Test Pir API + @to_static + CINN.
+    """
+
+    def setUp(self):
+        paddle.seed(2022)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.dtype = "float32"
+
+        self.x_shape = [4, 65536, 128]
+        self.x = paddle.randn(self.x_shape, dtype=self.dtype)
+        self.x.stop_gradient = False
+
+    def eval_symbolic(self, net, use_cinn, profile):
+        input_spec = [
+            InputSpec(shape=self.x_shape, dtype=self.dtype),
+        ]
+        net = utils.apply_to_static(net, use_cinn, input_spec)
+        net.eval()
+        out = utils.run_with_profile(profile, net, self.x)
+        return out
+
+    def test_eval_symbolic(self):
+        profile = False
+        net = CINNSubGraphNet(
+            self.dtype, in_features=self.x_shape[-1], intermedia=32, out_features=128
+        )
+        cinn_out = self.eval_symbolic(net, use_cinn=True, profile=profile)
+        d2s_out = self.eval_symbolic(net, use_cinn=False, profile=profile)
+        # dy_out = utils.run_with_profile(profile, net, self.x)
+        if not profile:
+            utils.check_result(self.dtype, cinn_out.numpy(), d2s_out.numpy())
+            # utils.check_result(self.dtype, d2s_out.numpy(), dy_out.numpy())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
修复网络中匹配到多个子图时的运行问题，主要原因是每个动态库都需要自己调用一下`cudaFuncSetAttribute`函数来设置CUDA核最大共享内存的大小。