### PR TITLE
[Support] ternary mm-epilogue

### DIFF
--- a/tests/ap/__main__.py
+++ b/tests/ap/__main__.py
@@ -1,3 +1,2 @@
-# import test_trivial_reduce
-# import test_binary_trivial_reduce
 import test_matmul_binary
+import test_matmul_ternary

--- a/tests/ap/__main__.py
+++ b/tests/ap/__main__.py
@@ -1,2 +1,1 @@
-import test_matmul_binary
-import test_matmul_ternary
+import test_matmul_epilogue

--- a/tests/ap/kernel_arg_id_util.py
+++ b/tests/ap/kernel_arg_id_util.py
@@ -9,14 +9,18 @@ class KernelArgIdNameRegistry:
     self.in_tensor_data_ptr_seq_no = 0
     self.out_tensor_data_ptr_seq_no = 0
     self.dim_expr_seq_no = 0
+    self.output_nums = 0
 
   def get_or_create_kernel_arg_id_manul_var_name(self, kernel_arg_id, cpp_var_name):
     create = lambda: cpp_var_name
     return self.all_kernel_arg_id2unique_name.get_or_create(kernel_arg_id, create)
 
   def get_in_tensor_data_ptr_var_name(self, in_ir_value_name):
+    print('in_ir_value_name: ', in_ir_value_name)
     ir_value = getattr(self.tensor_match_ctx, in_ir_value_name)
+    print('ir_value: ', ir_value)
     kernel_arg_id = self.code_gen_ctx.in_tensor_data_ptr_kernel_arg_id(ir_value)
+    print('kernel_arg_id: ', kernel_arg_id)
     create = self._get_creator(kernel_arg_id, self._create_in_tensor_data_ptr_var_name)
     return self.generated_kernel_arg_id2unique_name.get_or_create(kernel_arg_id, create)
 
@@ -29,6 +33,8 @@ class KernelArgIdNameRegistry:
     return name
 
   def get_out_tensor_data_ptr_var_name(self, out_ir_value_name):
+    self.output_nums = self.output_nums + 1
+    out_ir_value_name = f"{out_ir_value_name}{self.output_nums}"
     ir_value = getattr(self.tensor_match_ctx, out_ir_value_name)
     kernel_arg_id = self.code_gen_ctx.out_tensor_data_ptr_kernel_arg_id(ir_value)
     create = self._get_creator(kernel_arg_id, self._create_out_tensor_data_ptr_var_name)

--- a/tests/ap/make_axpr.sh
+++ b/tests/ap/make_axpr.sh
@@ -6,7 +6,10 @@ TEST_FILENAME=${1:-"test_trivial_reduce"}
 TEST_TPL_FILENAME=`echo ${TEST_FILENAME/test_/}`
 
 echo "-- Write 'import ${TEST_FILENAME}' to __main__.py"
-echo "import ${TEST_FILENAME}" > __main__.py
+echo "-- Write 'import test_matmul_binary' to __main__.py"
+echo "import test_matmul_binary" > __main__.py
+echo "import test_matmul_ternary" >> __main__.py
+# echo "import ${TEST_FILENAME}" >> __main__.py
 
 
 FILENAMES_ARRAY=(
@@ -26,8 +29,10 @@ FILENAMES_ARRAY=(
     "access_topo_drr"
     "abstract_drr"
     "ap_tpl_codegen"
+	"matmul_binary_tpl"
+    "test_matmul_binary"
+    "test_matmul_ternary"
     "${TEST_FILENAME}"
-    "${TEST_TPL_FILENAME}_tpl"
 )
 for filename in "${FILENAMES_ARRAY[@]}"
 do

--- a/tests/ap/make_axpr.sh
+++ b/tests/ap/make_axpr.sh
@@ -6,10 +6,7 @@ TEST_FILENAME=${1:-"test_trivial_reduce"}
 TEST_TPL_FILENAME=`echo ${TEST_FILENAME/test_/}`
 
 echo "-- Write 'import ${TEST_FILENAME}' to __main__.py"
-echo "-- Write 'import test_matmul_binary' to __main__.py"
-echo "import test_matmul_binary" > __main__.py
-echo "import test_matmul_ternary" >> __main__.py
-# echo "import ${TEST_FILENAME}" >> __main__.py
+echo "import ${TEST_FILENAME}" > __main__.py
 
 
 FILENAMES_ARRAY=(
@@ -26,12 +23,12 @@ FILENAMES_ARRAY=(
     "__main__"
     "topo_drr_pass"
     "op_convertion_drr_pass"
+    "umprime"
     "access_topo_drr"
     "abstract_drr"
+    "matmul_epilogue_remove_pass"
     "ap_tpl_codegen"
     "matmul_binary_tpl"
-    "test_matmul_binary"
-    "test_matmul_ternary"
     "${TEST_FILENAME}"
 )
 for filename in "${FILENAMES_ARRAY[@]}"

--- a/tests/ap/make_axpr.sh
+++ b/tests/ap/make_axpr.sh
@@ -29,7 +29,7 @@ FILENAMES_ARRAY=(
     "access_topo_drr"
     "abstract_drr"
     "ap_tpl_codegen"
-	"matmul_binary_tpl"
+    "matmul_binary_tpl"
     "test_matmul_binary"
     "test_matmul_ternary"
     "${TEST_FILENAME}"

--- a/tests/ap/matmul_binary_tpl.py
+++ b/tests/ap/matmul_binary_tpl.py
@@ -94,6 +94,11 @@ class MatmulBinaryTemplate:
             lambda pair: pair[0].runtime_getter, all_kernel_arg_id_and_unique_names
         )
 
+    def init_outputs(self):
+        out_tensor_data_nums = self.mut_kernel_arg_id_registry.out_tensor_data_ptr_seq_no
+        stmt = map(lambda i: f"out{i}", range(out_tensor_data_nums + 1))
+        return "T " + f", ".join(stmt) + ";"
+
     def get_kernel_arg_types(self):
         all_kernel_arg_id_and_unique_names = (
             self.mut_kernel_arg_id_registry.all_kernel_arg_id2unique_name.items()
@@ -198,9 +203,9 @@ struct VariadicEpilogueFunctor {
   // Note: need to support vectorized operation
   __forceinline__ __host__ __device__
   T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
-    T out;
+    AP_OUTPUTS_INIT
     AP_GENERATED_BINARY_EPILOGUE_STRING
-    return out;
+    return out0;
   }
 };
 
@@ -238,6 +243,7 @@ void MatmulBinaryKernel(void* stream_ptr, AP_KERNEL_ARGS_DECLARE) {
                 "AP_GENERATED_BINARY_EPILOGUE_STRING", trivial_code_str
             )
             .replace("AP_GENERATED_ELEMENT_DTYPE", output_dtype)
+            .replace("AP_OUTPUTS_INIT", self.init_outputs())
             .replace("AP_KERNEL_ARGS_DECLARE", self.get_kernel_arg_list_str())
             .replace(
                 "AP_INPUT0_SHAPE_INIT",
@@ -258,7 +264,6 @@ void MatmulBinaryKernel(void* stream_ptr, AP_KERNEL_ARGS_DECLARE) {
             .replace("$input1", self.get_kernel_arg_id_var_name(input1_karg))
             .replace("$output", self.get_kernel_arg_id_var_name(output_karg))
         )
-
         source_dir = "/work/abstract_pass/Athena/tests/ap/matmul"
         cutlass_dir = "/work/abstract_pass/Athena/tests/ap/matmul/cutlass"
         compile_cmd = (

--- a/tests/ap/matmul_epilogue_remove_pass.py
+++ b/tests/ap/matmul_epilogue_remove_pass.py
@@ -1,0 +1,163 @@
+import access_topo_drr
+import pir
+
+class RemoveDataOpPairPass(access_topo_drr.DrrPass):
+  def __init__(self, src_data_op_name, dst_data_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_data_op_name = pir.a_str(dst_data_op_name)
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op(
+      [],
+      [t.input0]
+    )
+    o.dst_data_op = o.ap_native_op("pd_op.data")
+    o.dst_data_op(
+      [],
+      [t.input1]
+    )
+    o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    o.up_spider_op(
+      [t.input0, t.input1],
+      []
+    )
+  def constraint(self, o, t):
+    return [o.src_data_op.name, o.dst_data_op.name] == [self.src_data_op_name, self.dst_data_op_name]
+  def result_pattern(self, o, t):
+    pass
+
+class RemoveDataOp2SumOp2DataOpPass(access_topo_drr.DrrPass):
+  def __init__(self, src_data_op_name, dst_data_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_data_op_name = pir.a_str(dst_data_op_name)
+
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op.name = self.src_data_op_name
+    o.src_data_op(
+      [],
+      [t.input0]
+    )
+    o.full_int_array_op = o.ap_native_op("pd_op.full_int_array")
+    o.full_int_array_op(
+      [],
+      [t.axis]
+    )
+    o.sum_op = o.ap_native_op("pd_op.sum")
+    o.sum_op(
+      [t.input0, t.axis],
+      [t.sum_out]
+    )
+    o.dst_data_op = o.ap_native_op("pd_op.data")
+    o.dst_data_op.name = self.dst_data_op_name
+    o.dst_data_op(
+      [],
+      [t.input1]
+    )
+    o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    o.up_spider_op(
+      [t.sum_out, t.input1],
+      []
+    )
+
+  def result_pattern(self, o, t):
+    pass
+
+class RemoveElementInputIndexPass(access_topo_drr.DrrPass):
+
+  def __init__(self, src_data_op_name, dst_load_from_global_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_load_from_global_op_name = pir.a_str(dst_load_from_global_op_name)
+
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op.name = self.src_data_op_name
+    o.src_data_op(
+      [],
+      [t.src_input]
+    )
+
+    o.dst_load_from_global_op = o.ap_native_op("ap_op.load_from_global")
+    o.dst_load_from_global_op.index_func_unique_id = self.dst_load_from_global_op_name
+    o.dst_load_from_global_op(
+      [t.dst_input],
+      [t.dst_load_from_global_output]
+    )
+    o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    o.up_spider_op(
+      [t.src_input, t.dst_load_from_global_output],
+      []
+    )
+
+  def result_pattern(self, o, t):
+    pass
+
+class RemoveBroadcastInputIndexPass(access_topo_drr.DrrPass):
+  def __init__(self, src_data_op_name, dst_load_from_global_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_load_from_global_op_name = pir.a_str(dst_load_from_global_op_name)
+
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op.name = self.src_data_op_name
+    o.src_data_op(
+      [],
+      [t.input0]
+    )
+    o.full_int_array_op = o.ap_native_op("pd_op.full_int_array")
+    o.full_int_array_op(
+      [],
+      [t.axis]
+    )
+    o.sum_op = o.ap_native_op("pd_op.sum")
+    o.sum_op(
+      [t.input0, t.axis],
+      [t.sum_out]
+    )
+    o.dst_load_from_global_op = o.ap_native_op("ap_op.load_from_global")
+    o.dst_load_from_global_op.index_func_unique_id = self.dst_load_from_global_op_name
+    o.dst_load_from_global_op(
+      [t.dst_input],
+      [t.dst_load_from_global_output]
+    )
+    o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    o.up_spider_op(
+      [t.sum_out, t.dst_load_from_global_output],
+      []
+    )
+
+  def result_pattern(self, o, t):
+    pass
+
+class RemoveOutputIndexPass(access_topo_drr.DrrPass):
+
+  def __init__(self, src_data_op_name, dst_store_to_global_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_store_to_global_op_name = pir.a_str(dst_store_to_global_op_name)
+
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op.name = self.src_data_op_name
+    o.src_data_op(
+      [],
+      [t.src_input]
+    )
+    o.down_spider_op = o.ap_native_op("ap_op.down_spider")
+    o.down_spider_op(
+      [t.src_input],
+      [t.dst_output_val]
+    )
+    o.dst_store_to_global_op = o.ap_native_op("ap_op.store_to_global")
+    o.dst_store_to_global_op.index_func_unique_id = self.dst_store_to_global_op_name
+    o.dst_store_to_global_op(
+      [t.dst_output, t.dst_output_val],
+      []
+    )
+    # o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    # o.up_spider_op(
+    #   [t.src_input, t.dst_output_val],
+    #   []
+    # )
+
+  def result_pattern(self, o, t):
+    pass

--- a/tests/ap/op_compute_translator_util.py
+++ b/tests/ap/op_compute_translator_util.py
@@ -48,8 +48,11 @@ class ApOpLoadFromGlobalCodeGen:
       mut_lir_code_gen_ctx=mut_lir_code_gen_ctx,
     )
     data_op_name = inputs[0].var_name
+    print('data_op_name is: ', data_op_name)
     arg_name = mut_kernel_arg_id_registry.get_in_tensor_data_ptr_var_name(data_op_name)
+    print('arg_name is: ', arg_name)
     ptr_var_name = self.kernel_arg_translator.get_use_name(arg_name)
+    print('ptr_var_name is: ', ptr_var_name)
     out = self.get_out_cg_val(0)
     mut_lir_code_gen_ctx.let(out, f"{ptr_var_name}[{offset_var_name}]")
     return [out]
@@ -73,9 +76,58 @@ class ApOpStoreToRegisterCodeGen:
     self.output_properties = output_properties
     self.kernel_arg_translator = kernel_arg_translator
     self.index_program_translator_map = index_program_translator_map
+    self.dtype2type_name = OrderedDict(
+        [
+            [PointerType.const_float_ptr, "const float*"],
+            [PointerType.const_float16_ptr, "const half*"],
+            [PointerType.float_ptr, "float*"],
+            [PointerType.float16_ptr, "half*"],
+            [DataType.float, "float"],
+            [DataType.float16, "half"],
+            [DataType.int64_t, "int64_t"],
+        ]
+    )
+    self.ptr2type = OrderedDict(
+        [
+            ["float*", "float"],
+            ["half*", "half"],
+        ]
+    )
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
     mut_lir_code_gen_ctx.stmts.append(f"{self.get_out_var_name()} = {inputs[0].var_name};")
+    glb_out = OrderedDict(
+      map(lambda i: [f"out{i+1}", f"args.out_ptr_{i}"], range(20))
+    )
+    out_name = self.get_out_var_name()
+    print('out_name: ', out_name)
+    index_func_unique_id_attr = self.op_property.attributes.name if out_name != "out0" else []
+    index_func_unique_id = index_func_unique_id_attr.match(a_str=lambda x:x) if out_name != "out0" else []
+
+    mut_kernel_arg_id_registry.get_out_tensor_data_ptr_var_name('output') if out_name != "out0" else []
+    output_seq_name = f"out_ptr_{mut_kernel_arg_id_registry.output_nums - 1}" if out_name != "out0" else []
+    print('output_seq_name: ', output_seq_name)
+    generated_kernel_arg_id_and_names = (
+        mut_kernel_arg_id_registry.generated_kernel_arg_id2unique_name.items()
+    )
+    print('generated_kernel_arg_id_and_names: ', generated_kernel_arg_id_and_names)
+    kernel_arg_id = filter(
+      lambda item: item[1] == output_seq_name,
+      generated_kernel_arg_id_and_names
+    )[0] if out_name != "out0" else []
+    print(kernel_arg_id) if out_name != "out0" else []
+    dtype = kernel_arg_id[0].type if out_name != "out0" else []
+    type_name = self.dtype2type_name[dtype] if out_name != "out0" else []
+    data_type = self.ptr2type[type_name] if out_name != "out0" else []
+    offset_var_name = self.index_program_translator_map.get_offset_var_name(
+      index_func_unique_id=index_func_unique_id,
+      mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
+      mut_lir_code_gen_ctx=mut_lir_code_gen_ctx,
+    ) if out_name != "out0" else []
+    ptr_name = glb_out[out_name] if out_name != "out0" else []
+    mut_lir_code_gen_ctx.stmts.append(
+      f"{ptr_name}[{offset_var_name}] = static_cast<{data_type}>({out_name});"
+    ) if out_name != "out0" else []
     return []
 
   def get_out_var_name(self):
@@ -493,6 +545,22 @@ class CinnOpBroadcastCodeGen:
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
     return inputs
 
+class CinnOpExpandCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    return [inputs[0]]
+
 class CinnOpGenerateShapeCodeGen:
   def __init__(self,
                op_property,
@@ -539,6 +607,7 @@ class OpComputeTranslatorFactory:
       ["pd_op.maximum",             PdOpMaximumCodeGen],
       ["cinn_op.yield_store",       CinnOpYieldStoreCodeGen],
       ["cinn_op.broadcast",         CinnOpBroadcastCodeGen],
+      ["pd_op.expand",              CinnOpExpandCodeGen],
       ["cinn_op.generate_shape",    CinnOpGenerateShapeCodeGen]
     ])
 

--- a/tests/ap/op_compute_translator_util.py
+++ b/tests/ap/op_compute_translator_util.py
@@ -93,41 +93,39 @@ class ApOpStoreToRegisterCodeGen:
             ["half*", "half"],
         ]
     )
+    self.local_to_glb_out = OrderedDict(
+      map(lambda i: [f"out{i+1}", f"args.out_ptr_{i}"], range(20))
+    )
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
     mut_lir_code_gen_ctx.stmts.append(f"{self.get_out_var_name()} = {inputs[0].var_name};")
-    glb_out = OrderedDict(
-      map(lambda i: [f"out{i+1}", f"args.out_ptr_{i}"], range(20))
-    )
     out_name = self.get_out_var_name()
-    print('out_name: ', out_name)
-    index_func_unique_id_attr = self.op_property.attributes.name if out_name != "out0" else []
-    index_func_unique_id = index_func_unique_id_attr.match(a_str=lambda x:x) if out_name != "out0" else []
+    mut_kernel_arg_id_registry.get_out_tensor_data_ptr_var_name('output') if out_name != "out0" else None
 
-    mut_kernel_arg_id_registry.get_out_tensor_data_ptr_var_name('output') if out_name != "out0" else []
-    output_seq_name = f"out_ptr_{mut_kernel_arg_id_registry.output_nums - 1}" if out_name != "out0" else []
-    print('output_seq_name: ', output_seq_name)
-    generated_kernel_arg_id_and_names = (
-        mut_kernel_arg_id_registry.generated_kernel_arg_id2unique_name.items()
-    )
-    print('generated_kernel_arg_id_and_names: ', generated_kernel_arg_id_and_names)
-    kernel_arg_id = filter(
-      lambda item: item[1] == output_seq_name,
-      generated_kernel_arg_id_and_names
-    )[0] if out_name != "out0" else []
-    print(kernel_arg_id) if out_name != "out0" else []
-    dtype = kernel_arg_id[0].type if out_name != "out0" else []
-    type_name = self.dtype2type_name[dtype] if out_name != "out0" else []
-    data_type = self.ptr2type[type_name] if out_name != "out0" else []
-    offset_var_name = self.index_program_translator_map.get_offset_var_name(
-      index_func_unique_id=index_func_unique_id,
-      mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
-      mut_lir_code_gen_ctx=mut_lir_code_gen_ctx,
-    ) if out_name != "out0" else []
-    ptr_name = glb_out[out_name] if out_name != "out0" else []
-    mut_lir_code_gen_ctx.stmts.append(
-      f"{ptr_name}[{offset_var_name}] = static_cast<{data_type}>({out_name});"
-    ) if out_name != "out0" else []
+    def generate_store_stmt():
+      index_func_unique_id_attr = self.op_property.attributes.name 
+      index_func_unique_id = index_func_unique_id_attr.match(a_str=lambda x:x) 
+      output_seq_name = f"out_ptr_{mut_kernel_arg_id_registry.output_nums - 1}" 
+      generated_kernel_arg_id_and_names = (
+          mut_kernel_arg_id_registry.generated_kernel_arg_id2unique_name.items()
+      )
+      kernel_arg_id = filter(
+        lambda item: item[1] == output_seq_name,
+        generated_kernel_arg_id_and_names
+      )[0] 
+      dtype = kernel_arg_id[0].type 
+      type_name = self.dtype2type_name[dtype] 
+      data_type = self.ptr2type[type_name] 
+      offset_var_name = self.index_program_translator_map.get_offset_var_name(
+        index_func_unique_id=index_func_unique_id,
+        mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
+        mut_lir_code_gen_ctx=mut_lir_code_gen_ctx,
+      ) 
+      ptr_name = self.local_to_glb_out[out_name] 
+      mut_lir_code_gen_ctx.stmts.append(
+        f"{ptr_name}[{offset_var_name}] = static_cast<{data_type}>({out_name});"
+      ) 
+    generate_store_stmt() if out_name != "out0" else None
     return []
 
   def get_out_var_name(self):

--- a/tests/ap/op_convertion_drr_pass.py
+++ b/tests/ap/op_convertion_drr_pass.py
@@ -4,15 +4,15 @@ import access_topo_drr
 class PdOpCastAccessTopoPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):
-    o.exp_op = o.ap_native_op("pd_op.cast")
-    o.exp_op(
+    o.cast_op = o.ap_native_op("pd_op.cast")
+    o.cast_op(
       [t.input],
       [t.output]
     )
 
   def result_pattern(self, o, t):
-    o.fustion_op = o.ap_native_op("pd_op.relu")
-    o.fustion_op(
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
       [t.input],
       [t.output]
     )
@@ -21,15 +21,15 @@ class PdOpCastAccessTopoPass(access_topo_drr.DrrPass):
 class PdOpTanhAccessTopoPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):
-    o.exp_op = o.ap_native_op("pd_op.tanh")
-    o.exp_op(
+    o.tanh_op = o.ap_native_op("pd_op.tanh")
+    o.tanh_op(
       [t.input],
       [t.output]
     )
 
   def result_pattern(self, o, t):
-    o.fustion_op = o.ap_native_op("pd_op.relu")
-    o.fustion_op(
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
       [t.input],
       [t.output]
     )
@@ -38,15 +38,15 @@ class PdOpTanhAccessTopoPass(access_topo_drr.DrrPass):
 class PdOpErfAccessTopoPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):
-    o.exp_op = o.ap_native_op("pd_op.erf")
-    o.exp_op(
+    o.erf_op = o.ap_native_op("pd_op.erf")
+    o.erf_op(
       [t.input],
       [t.output]
     )
 
   def result_pattern(self, o, t):
-    o.fustion_op = o.ap_native_op("pd_op.relu")
-    o.fustion_op(
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
       [t.input],
       [t.output]
     )
@@ -79,8 +79,8 @@ class PdOpExpAccessTopoPass(access_topo_drr.DrrPass):
     )
 
   def result_pattern(self, o, t):
-    o.fustion_op = o.ap_native_op("pd_op.relu")
-    o.fustion_op(
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
       [t.input],
       [t.output]
     )
@@ -89,15 +89,15 @@ class PdOpExpAccessTopoPass(access_topo_drr.DrrPass):
 class CinnOpScaleAccessTopoPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):
-    o.exp_op = o.ap_native_op("cinn_op.scale")
-    o.exp_op(
+    o.scale_op = o.ap_native_op("cinn_op.scale")
+    o.scale_op(
       [t.input],
       [t.output]
     )
 
   def result_pattern(self, o, t):
-    o.fustion_op = o.ap_native_op("pd_op.relu")
-    o.fustion_op(
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
       [t.input],
       [t.output]
     )
@@ -113,8 +113,8 @@ class PdOpSinAccessTopoPass(access_topo_drr.DrrPass):
     )
 
   def result_pattern(self, o, t):
-    o.fustion_op = o.ap_native_op("pd_op.relu")
-    o.fustion_op(
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
       [t.input],
       [t.output]
     )
@@ -123,15 +123,15 @@ class PdOpSinAccessTopoPass(access_topo_drr.DrrPass):
 class CinnOpYieldStoreAccessTopoPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):
-    o.exp_op = o.ap_native_op("cinn_op.yield_store")
-    o.exp_op(
+    o.yeild_op = o.ap_native_op("cinn_op.yield_store")
+    o.yeild_op(
       [t.input],
       [t.output]
     )
 
   def result_pattern(self, o, t):
-    o.fustion_op = o.ap_native_op("pd_op.relu")
-    o.fustion_op(
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
       [t.input],
       [t.output]
     )
@@ -181,8 +181,8 @@ class PdOpMultiplyAccessTopoPass(access_topo_drr.DrrPass):
     )
 
   def result_pattern(self, o, t):
-    o.fustion_op = o.ap_native_op("pd_op.add")
-    o.fustion_op(
+    o.result_op = o.ap_native_op("pd_op.add")
+    o.result_op(
       [t.input0, t.input1],
       [t.output]
     )

--- a/tests/ap/op_index_translator_util.py
+++ b/tests/ap/op_index_translator_util.py
@@ -62,8 +62,13 @@ class PdOpSumCodeGen:
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
     input_iter_var_names = inputs[0].iter_var_names
+    # handle the cases with mm_out's dim != 3
+    reduced_axes = map(
+      lambda index: inputs[1].const_data[index], range(2)
+    ) if len(inputs[1].const_data) >= 3 else [0, 1] if len(inputs[1].const_data) == 1 else inputs[1].const_data
+
     reduced_axes_set = OrderedDict(
-      map(lambda x: [int(x), True], inputs[1].const_data)
+      map(lambda x: [int(x), True], reduced_axes)
     )
     non_reduced_axes = filter(
       lambda x: reduced_axes_set.contains(x) == False,
@@ -93,13 +98,20 @@ class CinnOpReshapeCodeGen:
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
     symbolic_shape = self.input_properties[0].symbolic_shape
+    print('symbolic_shape', symbolic_shape)
     def get_or_create_dim_var_name(dim_expr):
       arg_var_name = mut_kernel_arg_id_registry.get_dim_expr_var_name(dim_expr)
+      print('dim expr: ', dim_expr)
+      print('arg_var_name: ', arg_var_name)
       return self.kernel_arg_translator.get_use_name(arg_var_name)
+
+    rank = 3 if len(symbolic_shape) > 3 else len(symbolic_shape)
+    rank_bias = len(symbolic_shape) - 3 if len(symbolic_shape) > 3 else 0
+
     def get_dim_var_name(i):
-      dim_expr = symbolic_shape[i]
+      dim_expr = symbolic_shape[i + rank_bias]
       return get_or_create_dim_var_name(dim_expr)
-    rank = len(symbolic_shape)
+
     stride_dims_list = map(
       lambda num_dims: map(lambda i: get_dim_var_name(num_dims + i + 1), range(rank - 1 - num_dims)),
       range(rank)
@@ -108,6 +120,8 @@ class CinnOpReshapeCodeGen:
       lambda pair: [pair[0], *pair[1]],
       zip(inputs[0].iter_var_names, stride_dims_list)
     )
+    print('iter_var_names')
+    map(lambda x: print(x), inputs[0].iter_var_names)
     offset_expr = " + ".join(
       map(
         lambda elts: " * ".join(elts),
@@ -165,4 +179,5 @@ class OpIndexTranslatorFactory:
     )
 
   def _get_class(self, op_name):
+    print('handling op: ', op_name)
     return self.op_name2class[op_name]

--- a/tests/ap/paddle-tests/test_matmul_epilogue.py
+++ b/tests/ap/paddle-tests/test_matmul_epilogue.py
@@ -27,11 +27,15 @@ from paddle.static import InputSpec
 
 def trivial_matrix_binary(x, y, b):
     out = paddle.matmul(x, y)
-    return paddle.nn.functional.relu(out + b)
+    bias = out - b
+    relu = paddle.nn.functional.relu(out)
+    exp = paddle.exp(relu)
+    return bias, relu, exp
+    #return out - b, out
 
-def trivial_matrix_binary_gelu_true(x, y, b):
-    out = paddle.matmul(x, y)
-    return paddle.nn.functional.gelu(out + b, True)
+# def trivial_matrix_binary_gelu_true(x, y, b):
+#     out = paddle.matmul(x, y)
+#     return paddle.nn.functional.gelu(out + b, True)
 
 class CINNSubGraphNet(paddle.nn.Layer):
     def __init__(self, fn):
@@ -62,8 +66,8 @@ class TestAPMatmulBinaryTriangleShape(unittest.TestCase):
         self.y = paddle.randn(self.y_shape, dtype=self.dtype)
         self.y.stop_gradient = False
 
-        # self.b_shape = [32]
-        self.b_shape = [4, 65536, 32]
+        # self.b_shape = [4, 65536, 32]
+        self.b_shape = [32]
         self.b = paddle.randn(self.b_shape, dtype=self.dtype)
         self.b.stop_gradient = False
 
@@ -84,8 +88,9 @@ class TestAPMatmulBinaryTriangleShape(unittest.TestCase):
         cinn_out = self.eval_symbolic(use_cinn=True, profile=profile)
         dy_out = self.eval_symbolic(use_cinn=False, profile=profile)
         if not profile:
-            utils.check_result(self.dtype, cinn_out.numpy(), dy_out.numpy())
-
+            for i,(a,b) in enumerate(zip(cinn_out,dy_out)):
+                print(f'test_eval_symbolic: {i}')
+                utils.check_result(self.dtype, a.numpy(), b.numpy())
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ap/paddle-tests/test_matmul_ternary.py
+++ b/tests/ap/paddle-tests/test_matmul_ternary.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from os.path import dirname
+
+sys.path.append(dirname(__file__))
+
+import unittest
+
+import utils
+
+import paddle
+from paddle.static import InputSpec
+
+
+def trivial_matrix_binary(x, y, b, c):
+    out = paddle.matmul(x, y) - b + c
+    return out
+
+
+class CINNSubGraphNet(paddle.nn.Layer):
+    def __init__(self):
+        super().__init__()
+        self.fn = trivial_matrix_binary
+
+    def forward(self, x, y, b, c):
+        out = self.fn(x, y, b, c) 
+        return out
+
+
+class TestAPMatmulBinary(unittest.TestCase):
+    """
+    Test Pir API + @to_static + CINN.
+    """
+
+    def setUp(self):
+        paddle.seed(2022)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.dtype = "float16"
+
+        self.x_shape = [4, 65536, 256]
+        self.x = paddle.randn(self.x_shape, dtype=self.dtype)
+        self.x.stop_gradient = False
+
+        self.y_shape = [256, 256]
+        self.y = paddle.randn(self.y_shape, dtype=self.dtype)
+        self.y.stop_gradient = False
+
+        self.b_shape = [65536, 256]
+        self.b = paddle.randn(self.b_shape, dtype=self.dtype)
+        self.b.stop_gradient = False
+
+        self.c_shape = [65536, 256]
+        self.c = paddle.randn(self.c_shape, dtype=self.dtype)
+        self.c.stop_gradient = False
+
+    def eval_symbolic(self, use_cinn, profile):
+        net = CINNSubGraphNet()
+        input_spec = [
+            InputSpec(shape=self.x_shape, dtype=self.dtype),
+            InputSpec(shape=self.y_shape, dtype=self.dtype),
+            InputSpec(shape=self.b_shape, dtype=self.dtype),
+            InputSpec(shape=self.c_shape, dtype=self.dtype),
+        ]
+        net = utils.apply_to_static(net, use_cinn, input_spec)
+        net.eval()
+        out = utils.run_with_profile(profile, net, self.x, self.y, self.b, self.c)
+        return out
+
+    def test_eval_symbolic(self):
+        profile = False
+        cinn_out = self.eval_symbolic(use_cinn=True, profile=profile)
+        dy_out = self.eval_symbolic(use_cinn=False, profile=profile)
+        if not profile:
+            utils.check_result(self.dtype, cinn_out.numpy(), dy_out.numpy())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ap/program_translator_util.py
+++ b/tests/ap/program_translator_util.py
@@ -37,6 +37,7 @@ class ProgramTranslator:
       mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
       mut_lir_code_gen_ctx=mut_lir_code_gen_ctx
     )
+    print('op_outputs are: ', outputs)
     map(self._set_translated_value, zip(op_property.output_value_indexes, outputs))
 
   def _get_value_property(self, i):

--- a/tests/ap/test_all_matmul_graphs.py
+++ b/tests/ap/test_all_matmul_graphs.py
@@ -53,7 +53,17 @@ def cal_successful_rate(log_dir):
             else:
                 # cmd = ["mv", f"{log_dir}/{file_name}", f"{log_dir}/y{file_name}"]
                 pass
-    print('ap coverage rate: ', ap_num / float(sum_num))
+            fd = os.popen(f"cat {log_dir}/{file_name} |  grep '\"pd_op.matmul' | wc -l")
+            output = fd.read()
+            output = output.strip()
+            file_name_short = file_name.strip("log_test_sequence_").strip(".txt")
+            fusion_num = int(output[0])
+            if fusion_num >= 1:
+                pass
+            else:
+                sum_num -= 1
+                print(f'No matmul found in {file_name_short}')
+    print('total: ', sum_num, 'containing ap fusion: ', ap_num, 'ap coverage rate: ', ap_num / float(sum_num))
 
 def hash_code(*args, **kwargs):
     return time.strftime("%Y-%m-%d_%H:%M:%S")

--- a/tests/ap/test_all_matmul_graphs.py
+++ b/tests/ap/test_all_matmul_graphs.py
@@ -1,0 +1,82 @@
+import shutil
+import os
+import os.path
+import random
+import sys
+from subprocess import run, CalledProcessError, TimeoutExpired
+import time
+import hashlib
+import string
+
+log_root = "/work/Paddle/Athena/tests/ap/ap_matmul_graphs/"
+dir_name = "/work/PaddleTest/"
+shell_script = "/work/Paddle/Athena/"
+priority_cases_str = "01f387927f59470e4d98ffd80183e55c,05958b7bce36d4f49a9c58949af92e5f,0b1e9e1811c2caaab597bbc30dc64f15,1300635db023d0d4fc989f55acaeb68c,258da0d281b03ff3e9d485112427b2e0,30c6df92480843563881b3547ef00a70,32b3c2445138bb176126ec49ce12b920,360f44fe695c9d2d2bb3e0e2b0dec8ac,3cbeaa359cf1f5213ef9b53e84991175,4745af600b1a1a2e571860b739abdf51,51ccf25fcaf79fe57807277986c95abe,5205b522fb5d36186a4e1a2fe841d888,5a7a71c544c3f6d7f503189e31cb8224,5be1aef63a75b06b9d4607f14874dcca,623fe5f470e8682954dc6ba1d25405a7,6241136fcffe5083b24443ec6018217e,63d9162b25876e4243c844dd2712cba8,64902819a5b144aa518dcc1b62619713,6585ddf0dfb3b8aca54220e05c760d87,6739319539b71905d9cd2fa6b6e69993,6df4c95df0beee147bade3fea12cbfc8,6e8ea012e0a6cd1cd4539486497f5a88,6fd72e19394a8db2c8fed04b1fa01752,7b6c128e41453ea52c85c02b7c3a9d3a,801916bb28c4ae55391799323a72e97f,833cb0c8a48c02f8c845749b53866b79,8b7e7925cc84a4c14bc8de33f406b0f7,94f503573a1ce7dc15457fe473995d31,9642da331ae02f289778014a1edcbdc1,9683464a1fe31aad86eccf1a85acb73c,9acfbcce718bf2b38fa02cdf5ff38910,9d9701ea5a62c96bc6c62b330e7e8468,9dec831d26e88185dcb1986bb8adc440,9e11e7abbbff9e92aba537a6b1638525,9fa97bc70a143d3d5b9582c1ba2d4272,a203a286f7c0b99d676299abbb619170,a4d35b423347cdc00e1644c76ee320c4,a58889e1be5e32da7c6fa77c0be9195c,a698d689d224203b88f6ecbdbb7a3fe1,a6b0ed75b1eb7f1a1f3759d242d1b87a,aa462034c34ecd897f35e22b2b9cf9f8,aec45446b61a083b6a4e014a04e6f009,af3e782a6a41b342a6c59d9a853347d4,b142765b86967084713a3e8745ffe619,b3c116f98f26b175738166e7645eb869,b3fde09b1620ec2e4fb965ff33b2a483,b4cf9857f6257675d7c2bf06e211b638,b7c8f4e6dcc0c46d1f776e8d8a95bad3,b99897a41050399f9764ace87b218eb3,bbbdf176b7ed6336c10f5c2ca476b418,be6b8412cfb95999692e178d0aa8695c,be734570fe5aeb67473c9283d555538a,c0195ecb1a43c55192478a6d05ee7e58,c855449d99a4d85c32c87cfb9e5e5b1e,c880f59a081a5e304fcaee03a373ea82,ce1267a5f57b3040514d414764bc9017,d2b60d61247483ca217400d03e27ce02,d41e4c8cbf723cad95ca49bb968a820d,d737d027e82af5a5d51dc3f0cbf99f53,e040cb6ba8ddc57e3b9da4773ac8f08b,e173ac7061eebb7935c1efc78338b97a,e2aab794d893c2b993becce389b47b51,e32419e9e757c11bb18dea11e052aec9,ea9eca45d1609de210a9f9bf55feb079,ebfbe603265d50f8afbb5029d9435fee,f4ede8a0f94c5daa2ad572d969d5d311,f6fd6824ed9f46608b1946e3c38878ac,f8136c4d286b6bc602ca932ac65d9e0a,fbf699eec701872c7fd286a2a6821bc1,fc4365802da42bfb7e905cb00f5de671,fcf544c4f0f0189f51c2edd76ca03f02,fef08e9fd2d93fe75aaeb0b4cdc76953"
+
+def test_all_graphs(log_dir, test_all_case = False):
+    priority_cases = set(["test_sequence_" + x + "_0" for x in priority_cases_str.split(",")])
+    for file_name in os.listdir(dir_name + "/framework/e2e/PaddleLT_new/layerE2Ecase/matmul-related-subgraphs/"):
+        # For phase1-2 cases:
+        file_seq_num = file_name.rstrip('.py')
+        if file_seq_num not in priority_cases:
+            print(f"Skipping non-phase1-2 case {file_seq_num}")
+            continue
+        test_case_type = ".py" if test_all_case else "_0.py" # 142 types of cases all end with 01.py
+        if file_name.endswith(test_case_type):
+            cmd = ["bash", shell_script + "/tests/ap/test_matmul_auto.sh", file_seq_num, log_dir]
+            fp = open(f"{log_dir}/log.txt", "a")
+            try:  #!! pack them
+                time_begin = time.time()
+                rcode = run(cmd, timeout= 100)
+                time_end = time.time()
+                print(f"Case {file_seq_num} finished in {time_end - time_begin:.1f} seconds.", end='\n', file=fp)
+            except CalledProcessError:
+                print(f"Error detected in initial check of case {file_seq_num}.", end='\n', file=fp)
+                keep_dir = True
+            except TimeoutExpired:
+                print(f"Case {file_seq_num} timed out.", end='\n', file=fp)
+
+def cal_successful_rate(log_dir):
+    ap_num = 0
+    files = os.listdir(log_dir)
+    sum_num = len(files) - 1 # there is a total log in the dir
+    for file_name in files:
+        if file_name.endswith('.txt'):
+            fd = os.popen(f"cat {log_dir}/{file_name} |  grep '\"pd_op.ap' | wc -l")
+            output = fd.read()
+            output = output.strip()
+            file_name_short = file_name.strip("log_test_sequence_").strip(".txt")
+            fusion_num = int(output[0])
+            if fusion_num >= 1:
+                ap_num += 1
+                print(f'{fusion_num} AP fusion found in {file_name_short}')
+            else:
+                # cmd = ["mv", f"{log_dir}/{file_name}", f"{log_dir}/y{file_name}"]
+                pass
+    print('ap coverage rate: ', ap_num / float(sum_num))
+
+def hash_code(*args, **kwargs):
+    return time.strftime("%Y-%m-%d_%H:%M:%S")
+
+
+if __name__ == "__main__":
+    if not os.path.exists(dir_name):
+        print("<Path Error> : Please Initialize the `dir_name` variable in\
+             test_matmul_graphs.py with the location of PaddleTest.")
+        exit(0)
+    if not os.path.exists(shell_script):
+        print("<Path Error> : Please Initialize the `shell_script` variable in\
+             test_matmul_graphs.py with the location of Athena.")
+        exit(0)
+    if not os.path.exists(log_root):
+        try:
+            os.mkdir(log_root)
+        except:
+            print("<Path Error> : Please Initialize the `log_root` variable with\
+             a valid directory.")
+            exit(0)
+    log_dir = log_root + "/" + hash_code()
+    shutil.rmtree(log_dir, ignore_errors=True)
+    os.mkdir(log_dir)
+    test_all_graphs(log_dir, test_all_case = False)
+    cal_successful_rate(log_dir)

--- a/tests/ap/test_ap_coverage_rate.py
+++ b/tests/ap/test_ap_coverage_rate.py
@@ -1,0 +1,56 @@
+import os
+import os.path
+import random
+import sys
+from subprocess import run, CalledProcessError, TimeoutExpired
+import time
+import hashlib
+import string
+from pathlib import Path
+
+log_root = "/work/Paddle/Athena/"
+
+def get_latest_subdirectory(directory):
+    paths = [path for path in Path(directory).iterdir() if path.is_dir()]
+    if not paths:
+        return None
+    latest_subdir = max(paths, key=lambda x: x.stat().st_mtime)
+    return str(latest_subdir)
+
+def cal_successful_rate(log_dir):
+    ap_num = 0
+    files = os.listdir(log_dir)
+    sum_num = len(files) - 1 # there is a total log in the dir
+    for file_name in files:
+        if file_name.endswith('.txt'):
+            fd = os.popen(f"cat {log_dir}/{file_name} |  grep '\"pd_op.ap' | wc -l")
+            output = fd.read()
+            output = output.strip()
+            file_name_short = file_name.strip("log_test_sequence_").strip(".txt")
+            fusion_num = int(output[0])
+            if fusion_num >= 1:
+                ap_num += 1
+                print(f'{fusion_num} AP fusion found in {file_name_short}')
+            else:
+                # cmd = ["mv", f"{log_dir}/{file_name}", f"{log_dir}/y{file_name}"]
+                pass
+            fd = os.popen(f"cat {log_dir}/{file_name} |  grep '\"pd_op.matmul' | wc -l")
+            output = fd.read()
+            output = output.strip()
+            file_name_short = file_name.strip("log_test_sequence_").strip(".txt")
+            fusion_num = int(output[0])
+            if fusion_num >= 1:
+                pass
+            else:
+                sum_num -= 1
+                print(f'No matmul found in {file_name_short}')
+    print('total: ', sum_num, 'containing ap fusion: ', ap_num, 'ap coverage rate: ', ap_num / float(sum_num))
+
+if __name__ == "__main__":
+    if not os.path.exists(log_root):
+        print("<Path Error> : Please Initialize the `log_root` variable with\
+            a existed log directory.")
+        exit(0)
+    latest_subdir = get_latest_subdirectory(log_root + "tests/ap/ap_matmul_graphs/")
+    print("latest_subdir: ", latest_subdir)
+    cal_successful_rate(latest_subdir)

--- a/tests/ap/test_calculate_successful_rate.py
+++ b/tests/ap/test_calculate_successful_rate.py
@@ -1,0 +1,46 @@
+import os
+import os.path
+import random
+import sys
+from subprocess import run, CalledProcessError, TimeoutExpired
+import time
+import hashlib
+import string
+from pathlib import Path
+
+log_root = "/work/Paddle/Athena/"
+
+def get_latest_subdirectory(directory):
+    paths = [path for path in Path(directory).iterdir() if path.is_dir()]
+    if not paths:
+        return None
+    latest_subdir = max(paths, key=lambda x: x.stat().st_mtime)
+    return str(latest_subdir)
+
+def cal_successful_rate(log_dir):
+    ap_num = 0
+    files = os.listdir(log_dir)
+    sum_num = len(files) - 1 # there is a total log in the dir
+    for file_name in files:
+        if file_name.endswith('.txt'):
+            fd = os.popen(f"cat {log_dir}/{file_name} |  grep '\"pd_op.ap' | wc -l")
+            output = fd.read()
+            output = output.strip()
+            file_name_short = file_name.strip("log_test_sequence_").strip(".txt")
+            fusion_num = int(output[0])
+            if fusion_num >= 1:
+                ap_num += 1
+                print(f'{fusion_num} AP fusion found in {file_name_short}')
+            else:
+                # cmd = ["mv", f"{log_dir}/{file_name}", f"{log_dir}/y{file_name}"]
+                pass
+    print('ap coverage rate: ', ap_num / float(sum_num))
+
+if __name__ == "__main__":
+    if not os.path.exists(log_root):
+        print("<Path Error> : Please Initialize the `log_root` variable with\
+            a existed log directory.")
+        exit(0)
+    latest_subdir = get_latest_subdirectory(log_root + "tests/ap/ap_matmul_graphs/")
+    print("latest_subdir: ", latest_subdir)
+    cal_successful_rate(latest_subdir)

--- a/tests/ap/test_matmul_auto.sh
+++ b/tests/ap/test_matmul_auto.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -x
+export CUDA_VISIBLE_DEVICES="4"
+export NVIDIA_TF32_OVERRIDE=0
+sh make_axpr.sh test_matmul_epilogue
+FILE_NUM=$1
+LOG_DIR=$2
+TEST_DIR=/work/PaddleTest/framework/e2e/PaddleLT_new/layerE2Ecase/matmul-related-subgraphs/
+FILENAME=${TEST_DIR}/${FILE_NUM}.py
+
+export FLAGS_enable_ap=1
+export NVIDIA_TF32_OVERRIDE=1
+export AP_WORKSPACE_DIR=$(pwd)/ap_workspace
+export AP_PATH=$(pwd)/
+export ATHENA_ENABLE_TRY_RUN=0
+export FLAGS_check_infer_symbolic=1
+export FLAGS_enable_pir_api=1
+export FLAGS_cinn_bucket_compile=True
+export FLAGS_prim_enable_dynamic=True
+export FLAGS_prim_all=True
+export FLAGS_pir_apply_shape_optimization_pass=1
+export FLAGS_group_schedule_tiling_first=1
+export FLAGS_cinn_new_group_scheduler=1
+# export FLAGS_cinn_enable_vectorize=true
+
+# export GLOG_v=6
+
+# export PATH=/opt/nvidia/nsight-systems/2023.4.1/bin:$PATH
+#nsys_args="nsys profile --stats true -w true -t cuda,nvtx,osrt,cudnn,cublas --capture-range=cudaProfilerApi -x true --force-overwrite true -o ${FILENAME}"
+
+# ${nsys_args}
+GLOG_vmodule=ap_lower_fusion_op_pass=8 python $FILENAME 2>&1 | tee "${LOG_DIR}/log_${FILE_NUM}.txt"

--- a/tests/ap/test_matmul_binary.py
+++ b/tests/ap/test_matmul_binary.py
@@ -276,6 +276,7 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
           self, compute_program, anchor_data_op_name, input_names, output_names):
     full_index_program = compute_program.clone()
     self._apply_topo_access_passes(full_index_program, anchor_data_op_name)
+    print('full_index_program:', full_index_program)
     def MatchAndCopyInputIndex(dst_input_name):
         pass_manager = ir_tools.create_pass_manager()
         removed_programs = MutableList()

--- a/tests/ap/test_matmul_binary.sh
+++ b/tests/ap/test_matmul_binary.sh
@@ -1,6 +1,6 @@
 export CUDA_VISIBLE_DEVICES="0"
 export NVIDIA_TF32_OVERRIDE=0
 
-sh make_axpr.sh test_matmul_binary
+sh make_axpr.sh test_matmul_epilogue
 
-FLAGS_enable_ap=1 AP_WORKSPACE_DIR=$(pwd)/ap_workspace AP_PATH=$(pwd)/ FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 FLAGS_cinn_bucket_compile=True FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True FLAGS_pir_apply_shape_optimization_pass=1 FLAGS_group_schedule_tiling_first=1 FLAGS_cinn_new_group_scheduler=1 python3.9 $(pwd)/paddle-tests/test_matmul_binary.py
+FLAGS_enable_ap=1 AP_WORKSPACE_DIR=$(pwd)/ap_workspace AP_PATH=$(pwd)/ FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 FLAGS_cinn_bucket_compile=True FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True FLAGS_pir_apply_shape_optimization_pass=1 FLAGS_group_schedule_tiling_first=1 FLAGS_cinn_new_group_scheduler=1 python $(pwd)/paddle-tests/test_matmul_binary.py

--- a/tests/ap/test_matmul_epilogue.py
+++ b/tests/ap/test_matmul_epilogue.py
@@ -1,0 +1,546 @@
+import abstract_drr
+import access_topo_drr
+import topo_drr_pass
+import umprime
+import matmul_epilogue_remove_pass
+import op_convertion_drr_pass
+import matmul_binary_tpl
+import ir_tools
+import index_program_translator_util
+import op_compute_translator_util
+import program_translator_util
+import kernel_arg_id_util
+import low_level_ir_code_gen_ctx_util
+import kernel_arg_translator_util
+import pir
+
+
+class MatmulEpilogueFusion(abstract_drr.DrrPass):
+  def source_pattern(self, o, t):
+    in_num = self.number_of_inputs()
+    out_num = self.number_of_outputs()
+    o.matmul_op = o.ap_native_op("pd_op.matmul")
+    o.matmul_op(
+        [t.input0, t.input1],
+        [t.mm_out]
+    )
+    o.trivial_op = o.ap_trivial_fusion_op()
+    o.trivial_op(
+      [t.mm_out, *map(lambda index: getattr(t, f"input{index+2}"),  range(in_num - 2))],
+      map(lambda index: getattr(t, f"output{index}"),  range(out_num)),
+    )
+
+
+  def result_pattern(self, o, t):
+    in_num = self.number_of_inputs()
+    out_num = self.number_of_outputs()
+    o.fustion_op = o.ap_pattern_fusion_op(self.code_gen)
+    o.fustion_op(
+      map(lambda index: getattr(t, f"input{index}"),  range(in_num)),
+      map(lambda index: getattr(t, f"output{index}"),  range(out_num)),
+    )
+
+  def constraint(self, o, t):
+    program = ir_tools.copy_fused_ops_to_program(o.trivial_op, tensor_match_ctx=t)
+    print("before-umprime: ", program)
+    # umprime passes
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("umprime"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("before-access_topo_pass", program)
+    init_pass_manager = ir_tools.create_pass_manager()
+    init_down_spider = topo_drr_pass.InitDownSpiderAccessTopoPass("mm_out")
+    init_pass_manager.add_pass(
+        ir_tools.create_access_topo_drr_one_step_pass(init_down_spider)
+    )
+    outputs_name_list = map(lambda i: f"output{i}", range(self.number_of_outputs()))
+    inputs_name_list = map(lambda i: f"input{i+2}", range(self.number_of_inputs() - 2)) if self.number_of_inputs() > 2 else []
+    print('inputs_name_list: ', ', '.join(inputs_name_list))
+    init_fake_data_for_yield_input = topo_drr_pass.FakeDataForYieldAccessTopoPass(
+      outputs_name_list
+    )
+    init_pass_manager.add_pass(
+        ir_tools.create_access_topo_drr_one_step_pass(init_fake_data_for_yield_input)
+    )
+    init_pass_manager.run(program)
+    print("after-init-access_topo_pass", program)
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("default"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("after-apply-access_topo_pass", program)
+    pass_manager = ir_tools.create_pass_manager()
+    map(lambda dst_name: pass_manager.add_pass(
+      ir_tools.create_access_topo_drr_one_step_pass(
+          matmul_epilogue_remove_pass.RemoveDataOpPairPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
+          inputs_name_list
+    )
+    map(lambda dst_name: pass_manager.add_pass(
+      ir_tools.create_access_topo_drr_one_step_pass(
+          matmul_epilogue_remove_pass.RemoveDataOp2SumOp2DataOpPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
+          inputs_name_list
+    )
+
+    map(lambda dst_name: pass_manager.add_pass(
+      ir_tools.create_access_topo_drr_one_step_pass(
+          matmul_epilogue_remove_pass.RemoveDataOpPairPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
+          outputs_name_list
+    )
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("after-remove-input-output-access_topo_pass", program)
+    return program.empty()
+
+  def _insert_load_from_global(self, program, input_names):
+    init_pass_manager = ir_tools.create_pass_manager()
+    def AddPass(input_name):
+        ir_pass = topo_drr_pass.InitNaiveLoadFromGlobalAccessTopoPass(input_name)
+        init_pass_manager.add_pass(
+            ir_tools.create_access_topo_drr_one_step_pass(ir_pass)
+        )
+    map(AddPass, input_names)
+    init_pass_manager.run(program)
+
+  def _insert_store_to_global(self, program, output_names):
+    init_pass_manager = ir_tools.create_pass_manager()
+    ir_pass = topo_drr_pass.FakeDataStoreToGlobalForYieldAccessTopoPass(output_names)
+    init_pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(ir_pass))
+    init_pass_manager.run(program)
+
+  def _make_kernel_arg_translator(self):
+    return matmul_binary_tpl.make_kernel_arg_translator()
+
+  def _apply_topo_access_passes(self, mut_program, anchor_data_op_name):
+    init_pass_manager = ir_tools.create_pass_manager()
+    init_down_spider = topo_drr_pass.InitDownSpiderAccessTopoPass(anchor_data_op_name)
+    init_pass_manager.add_pass(
+        ir_tools.create_access_topo_drr_one_step_pass(init_down_spider)
+    )
+    init_pass_manager.run(mut_program)
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("default"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+
+  def _simplify_index_program(self, mut_program):
+    pass_manager = ir_tools.create_pass_manager()
+    drr_pass = topo_drr_pass.ConvertUpSpiderStoreDataOpToYieldOpPass()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    drr_pass = topo_drr_pass.ConvertDownSpiderStoreDataOpToYieldOpPass()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    return mut_program
+
+  def _make_index_func_unique_id2index_program(
+          self, compute_program, anchor_data_op_name, input_names, output_names):
+    full_index_program = compute_program.clone()
+    self._apply_topo_access_passes(full_index_program, anchor_data_op_name)
+    print('full_index_program: ', full_index_program)
+    def MatchAndCopyInputIndex(dst_input_name):
+        pass_manager = ir_tools.create_pass_manager()
+        removed_programs = MutableList()
+        rm_elementwise_drr_pass = matmul_epilogue_remove_pass.RemoveElementInputIndexPass(
+            src_data_op_name=anchor_data_op_name,
+            dst_load_from_global_op_name=dst_input_name
+        )
+        rm_elementwise_ir_pass = ir_tools.create_access_topo_drr_one_step_pass(
+            rm_elementwise_drr_pass,
+            matched_pattern_mut_list=removed_programs
+        )
+        pass_manager.add_pass(rm_elementwise_ir_pass)
+        rm_broadcast_drr_pass = matmul_epilogue_remove_pass.RemoveBroadcastInputIndexPass(
+            src_data_op_name=anchor_data_op_name,
+            dst_load_from_global_op_name=dst_input_name
+        )
+        rm_broadcast_ir_pass = ir_tools.create_access_topo_drr_one_step_pass(
+            rm_broadcast_drr_pass,
+            matched_pattern_mut_list=removed_programs
+        )
+        pass_manager.add_pass(rm_broadcast_ir_pass)
+        pass_manager.run(full_index_program)
+        def Converter(program):
+          return [dst_input_name, self._simplify_index_program(program)]
+        return map(Converter, removed_programs)
+    input_and_index_programs = flat_map(MatchAndCopyInputIndex, input_names)
+    def MatchAndCopyOutputIndex(dst_output_name):
+        print('full_index_program output: ', full_index_program)
+        pass_manager = ir_tools.create_pass_manager()
+        removed_programs = MutableList()
+        drr_pass = matmul_epilogue_remove_pass.RemoveOutputIndexPass(
+            src_data_op_name=anchor_data_op_name,
+            dst_store_to_global_op_name=dst_output_name
+        )
+        ir_pass = ir_tools.create_access_topo_drr_one_step_pass(
+            drr_pass,
+            matched_pattern_mut_list=removed_programs
+        )
+        pass_manager.add_pass(ir_pass)
+        pass_manager.run(full_index_program)
+
+        def Converter(program):
+          return [dst_output_name, self._simplify_index_program(program)]
+        print('len removed of output: ', len(removed_programs))
+        return map(Converter, removed_programs)
+    output_and_index_programs = flat_map(MatchAndCopyOutputIndex, output_names)
+    return OrderedDict([*input_and_index_programs, *output_and_index_programs])
+
+  def _replace_with_load_from_register(
+      self, mut_program, load_ir_value_name, register_var_name):
+    pass_manager = ir_tools.create_pass_manager()
+    drr_pass = topo_drr_pass.ReplaceWithLoadFromRegisterPass(
+        name=load_ir_value_name,
+        register_var_name=register_var_name
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    return mut_program
+
+  def _replace_with_store_to_register(
+      self, mut_program, store_ir_value_name, register_var_name):
+    pass_manager = ir_tools.create_pass_manager()
+    drr_pass = topo_drr_pass.ReplaceWithStoreToRegisterPass(
+        name=store_ir_value_name,
+        register_var_name=register_var_name
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    return mut_program
+
+  def _get_program_translator(self, ctx, o, t):
+    outputs_name_list = map(lambda i: f"output{i}", range(self.number_of_outputs()))
+    other_outputs_name_list = map(lambda i: f"output{i+1}", range(self.number_of_outputs()-1))
+    local_outputs_name_list = map(lambda i: f"out{i}", range(self.number_of_outputs()))
+    inputs_name_list = map(lambda i: f"input{i+2}", range(self.number_of_inputs() - 2)) if self.number_of_inputs() > 2 else []
+    mut_program = ir_tools.copy_fused_ops_to_program(
+      o.trivial_op, tensor_match_ctx=t
+    )
+    print("before-umprime: ", mut_program)
+    # umprime passes
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("umprime"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    self._insert_load_from_global(
+      mut_program,
+      input_names=["mm_out"]
+    )
+    self._insert_load_from_global(
+      mut_program,
+      input_names=inputs_name_list
+    )
+    self._insert_store_to_global(
+      mut_program,
+      output_names=outputs_name_list
+    )
+    kernel_arg_translator = self._make_kernel_arg_translator()
+    index_func_unique_id2index_program = self._make_index_func_unique_id2index_program(
+      mut_program,
+      anchor_data_op_name="mm_out",
+      input_names=inputs_name_list,
+      output_names=other_outputs_name_list,
+    )
+    print("index_func_unique_id2index_program:\n", index_func_unique_id2index_program)
+    index_program_translator_map = index_program_translator_util.IndexProgramTranslatorMap(
+      index_func_unique_id2index_program=index_func_unique_id2index_program,
+      kernel_arg_translator=kernel_arg_translator,
+      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names()
+    )
+    self._replace_with_load_from_register(
+      mut_program,
+      load_ir_value_name="mm_out",
+      register_var_name="x"
+    )
+    out_pair = zip(outputs_name_list, local_outputs_name_list)
+    map(lambda pair: self._replace_with_store_to_register(
+          mut_program,
+          store_ir_value_name=pair[0],
+          register_var_name=pair[1]
+        ), out_pair
+    )
+    print("mut_program:", mut_program)
+    op_compute_translator_maker = op_compute_translator_util.OpComputeTranslatorFactory()
+    print('berfore translator')
+    program_translator = program_translator_util.ProgramTranslator(
+      program_property=mut_program.copy_to_const_program_data(),
+      kernel_arg_translator=kernel_arg_translator,
+      index_program_translator_map=index_program_translator_map,
+      op_translator_maker=op_compute_translator_maker
+    )
+    print('after translator')
+
+    return program_translator
+
+  def code_gen(self, ctx, o, t):
+    program_translator = self._get_program_translator(ctx, o, t)
+    mut_kernel_arg_id_registry = kernel_arg_id_util.KernelArgIdNameRegistry(
+      code_gen_ctx=ctx,
+      tensor_match_ctx=t,
+      name_prefix=""
+    )
+    print('after registry')
+
+    template_module = matmul_binary_tpl.MatmulBinaryTemplate(
+      program_translator=program_translator,
+      mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
+    )
+    print('after module')
+
+    def get_symbolic_shape_args_list(sym_dim):
+        return ctx.dim_expr_kernel_arg_id(sym_dim)
+    input0_shape_kargs = map(get_symbolic_shape_args_list, t.input0.symbolic_shape_to_list())
+    input1_shape_kargs = map(get_symbolic_shape_args_list, t.input1.symbolic_shape_to_list())
+    print('before compile')
+    return template_module.compile(
+        input0_karg=ctx.in_tensor_data_ptr_kernel_arg_id(t.input0),
+        input1_karg=ctx.in_tensor_data_ptr_kernel_arg_id(t.input1),
+        output_karg=ctx.out_tensor_data_ptr_kernel_arg_id(t.output0),
+        input0_shape_kargs=input0_shape_kargs,
+        input1_shape_kargs=input1_shape_kargs,
+    )
+
+class NumberOfInputsTrait0():
+  def number_of_inputs(self):
+    return 0
+
+class NumberOfInputsTrait1():
+  def number_of_inputs(self):
+    return 1
+
+class NumberOfInputsTrait2():
+  def number_of_inputs(self):
+    return 2
+
+class NumberOfInputsTrait3():
+  def number_of_inputs(self):
+    return 3
+
+class NumberOfInputsTrait4():
+  def number_of_inputs(self):
+    return 4
+
+class NumberOfInputsTrait5():
+  def number_of_inputs(self):
+    return 5
+
+class NumberOfInputsTrait6():
+  def number_of_inputs(self):
+    return 6
+
+class NumberOfInputsTrait7():
+  def number_of_inputs(self):
+    return 7
+
+class NumberOfInputsTrait8():
+  def number_of_inputs(self):
+    return 8
+
+class NumberOfInputsTrait9():
+  def number_of_inputs(self):
+    return 9
+
+class NumberOfInputsTrait10():
+  def number_of_inputs(self):
+    return 10
+
+class NumberOfInputsTrait11():
+  def number_of_inputs(self):
+    return 11
+
+class NumberOfInputsTrait12():
+  def number_of_inputs(self):
+    return 12
+
+class NumberOfInputsTrait13():
+  def number_of_inputs(self):
+    return 13
+
+class NumberOfInputsTrait14():
+  def number_of_inputs(self):
+    return 14
+
+class NumberOfInputsTrait15():
+  def number_of_inputs(self):
+    return 15
+
+class NumberOfInputsTrait16():
+  def number_of_inputs(self):
+    return 16
+
+class NumberOfInputsTrait17():
+  def number_of_inputs(self):
+    return 17
+
+
+class NumberOfOutputsTrait0():
+  def number_of_outputs(self):
+    return 0
+
+class NumberOfOutputsTrait1():
+  def number_of_outputs(self):
+    return 1
+
+class NumberOfOutputsTrait2():
+  def number_of_outputs(self):
+    return 2
+
+class NumberOfOutputsTrait3():
+  def number_of_outputs(self):
+    return 3
+
+class NumberOfOutputsTrait4():
+  def number_of_outputs(self):
+    return 4
+
+class NumberOfOutputsTrait5():
+  def number_of_outputs(self):
+    return 5
+
+class NumberOfOutputsTrait6():
+  def number_of_outputs(self):
+    return 6
+
+class NumberOfOutputsTrait7():
+  def number_of_outputs(self):
+    return 7
+
+class NumberOfOutputsTrait8():
+  def number_of_outputs(self):
+    return 8
+
+class NumberOfOutputsTrait9():
+  def number_of_outputs(self):
+    return 9
+
+class NumberOfOutputsTrait10():
+  def number_of_outputs(self):
+    return 10
+
+class NumberOfOutputsTrait11():
+  def number_of_outputs(self):
+    return 11
+
+class NumberOfOutputsTrait12():
+  def number_of_outputs(self):
+    return 12
+
+class NumberOfOutputsTrait13():
+  def number_of_outputs(self):
+    return 13
+
+class NumberOfOutputsTrait14():
+  def number_of_outputs(self):
+    return 14
+
+class NumberOfOutputsTrait15():
+  def number_of_outputs(self):
+    return 15
+
+class NumberOfOutputsTrait16():
+  def number_of_outputs(self):
+    return 16
+
+class NumberOfOutputsTrait17():
+  def number_of_outputs(self):
+    return 17
+
+class NumberOfOutputsTrait18():
+  def number_of_outputs(self):
+    return 18
+
+class NumberOfOutputsTrait19():
+  def number_of_outputs(self):
+    return 19
+
+class NumberOfOutputsTrait20():
+  def number_of_outputs(self):
+    return 20
+
+class NumberOfOutputsTrait21():
+  def number_of_outputs(self):
+    return 21
+
+class NumberOfOutputsTrait22():
+  def number_of_outputs(self):
+    return 22
+def get_mixin_class(base_class, number_of_inputs, number_of_outputs):
+  num_inputs_to_input_trait_class = [
+    None,
+    NumberOfInputsTrait1,
+    NumberOfInputsTrait2,
+    NumberOfInputsTrait3,
+    NumberOfInputsTrait3,
+    NumberOfInputsTrait4,
+    NumberOfInputsTrait5,
+    NumberOfInputsTrait6,
+    NumberOfInputsTrait7,
+    NumberOfInputsTrait8,
+    NumberOfInputsTrait9,
+    NumberOfInputsTrait10,
+    NumberOfInputsTrait11,
+    NumberOfInputsTrait12,
+    NumberOfInputsTrait13,
+    NumberOfInputsTrait14,
+    NumberOfInputsTrait15,
+    NumberOfInputsTrait16,
+    NumberOfInputsTrait17,
+  ]
+  num_outputs_to_output_trait_class = [
+    None,
+    NumberOfOutputsTrait1,
+    NumberOfOutputsTrait2,
+    NumberOfOutputsTrait3,
+    NumberOfOutputsTrait4,
+    NumberOfOutputsTrait5,
+    NumberOfOutputsTrait6,
+    NumberOfOutputsTrait7,
+    NumberOfOutputsTrait8,
+    NumberOfOutputsTrait9,
+    NumberOfOutputsTrait10,
+    NumberOfOutputsTrait11,
+    NumberOfOutputsTrait12,
+    NumberOfOutputsTrait13,
+    NumberOfOutputsTrait14,
+    NumberOfOutputsTrait15,
+    NumberOfOutputsTrait16,
+    NumberOfOutputsTrait17,
+    NumberOfOutputsTrait18,
+    NumberOfOutputsTrait19,
+    NumberOfOutputsTrait20,
+    NumberOfOutputsTrait21,
+    NumberOfOutputsTrait22,
+  ]
+  return type(
+    f"MatmulEpilogueFusion{number_of_inputs}_{number_of_outputs}",
+    [
+      base_class,
+      num_inputs_to_input_trait_class[number_of_inputs],
+      num_outputs_to_output_trait_class[number_of_outputs],
+    ],
+    BuiltinSerializableAttrMap()
+  )
+
+# abstract_drr.register_drr_pass("matmul_binary_outs_fusion", nice=0)(get_mixin_class(MatmulEpilogueFusion, 3, 2))
+
+def register_class(base_class, max_num_inputs, max_num_outputs):
+  def register_drr_class(num_inputs, num_outputs):
+    abstract_drr.register_drr_pass(f"matmul_binary_in{num_inputs}_out{num_outputs}_fusion", nice=0)(
+      get_mixin_class(base_class, num_inputs, num_outputs)
+    )
+
+  def register_num_inputs_drr_classes(num_inputs):
+
+    def register_num_outputs_drr_classes(num_outputs):
+      return register_drr_class(num_inputs+2, num_outputs+1)
+
+    map(register_num_outputs_drr_classes, range(max_num_outputs))
+    print('done max outputs')
+    return None
+
+  map(register_num_inputs_drr_classes, range(max_num_inputs))
+  return None
+
+register_class(base_class=MatmulEpilogueFusion, max_num_inputs=10, max_num_outputs=10)

--- a/tests/ap/test_matmul_epilogue.sh
+++ b/tests/ap/test_matmul_epilogue.sh
@@ -1,0 +1,6 @@
+export CUDA_VISIBLE_DEVICES="2"
+export NVIDIA_TF32_OVERRIDE=0
+
+sh make_axpr.sh test_matmul_epilogue
+
+FLAGS_enable_ap=1 AP_WORKSPACE_DIR=$(pwd)/ap_workspace AP_PATH=$(pwd)/ FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 FLAGS_cinn_bucket_compile=True FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True FLAGS_pir_apply_shape_optimization_pass=1 FLAGS_group_schedule_tiling_first=1 FLAGS_cinn_new_group_scheduler=1 python $(pwd)/paddle-tests/test_matmul_epilogue.py

--- a/tests/ap/test_matmul_ternary.py
+++ b/tests/ap/test_matmul_ternary.py
@@ -210,15 +210,6 @@ class MatmulTernaryFusion(abstract_drr.DrrPass):
     pass_manager.run(program)
     print("after-apply-access_topo_pass", program)
     pass_manager = ir_tools.create_pass_manager()
-    # remove_data_op_pair_pass = RemoveDataOpPairPass(
-    #   src_data_op_name="mm_out",
-    #   dst_data_op_name="input2"
-    # )
-    # pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(
-    #   remove_data_op_pair_pass
-    # ))
-    # pass_manager.run(program)
-    # print("after-apply-RemoveDataOpPairPass_pass", program)
     
     remove_data_op2sum_op2data_op_pass = RemoveDataOp2SumOp2DataOpPass(
       src_data_op_name="mm_out",

--- a/tests/ap/test_matmul_ternary.py
+++ b/tests/ap/test_matmul_ternary.py
@@ -1,0 +1,451 @@
+import abstract_drr
+import access_topo_drr
+import topo_drr_pass
+import op_convertion_drr_pass
+import matmul_binary_tpl
+import ir_tools
+import index_program_translator_util
+import op_compute_translator_util
+import program_translator_util
+import kernel_arg_id_util
+import low_level_ir_code_gen_ctx_util
+import kernel_arg_translator_util
+import pir
+
+class RemoveDataOpPairPass(access_topo_drr.DrrPass):
+  def __init__(self, src_data_op_name, dst_data_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_data_op_name = pir.a_str(dst_data_op_name)
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op(
+      [],
+      [t.input0]
+    )
+    o.dst_data_op = o.ap_native_op("pd_op.data")
+    o.dst_data_op(
+      [],
+      [t.input1]
+    )
+    o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    o.up_spider_op(
+      [t.input0, t.input1],
+      []
+    )
+  def constraint(self, o, t):
+    return [o.src_data_op.name, o.dst_data_op.name] == [self.src_data_op_name, self.dst_data_op_name]
+  def result_pattern(self, o, t):
+    pass
+
+class RemoveDataOp2SumOp2DataOpPass(access_topo_drr.DrrPass):
+  def __init__(self, src_data_op_name, dst_data_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_data_op_name = pir.a_str(dst_data_op_name)
+
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op.name = self.src_data_op_name
+    o.src_data_op(
+      [],
+      [t.input0]
+    )
+    o.full_int_array_op = o.ap_native_op("pd_op.full_int_array")
+    o.full_int_array_op(
+      [],
+      [t.axis]
+    )
+    o.sum_op = o.ap_native_op("pd_op.sum")
+    o.sum_op(
+      [t.input0, t.axis],
+      [t.sum_out]
+    )
+    o.dst_data_op = o.ap_native_op("pd_op.data")
+    o.dst_data_op.name = self.dst_data_op_name
+    o.dst_data_op(
+      [],
+      [t.input1]
+    )
+    o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    o.up_spider_op(
+    #   [t.sum_out, t.input1],
+      [t.sum_out, t.input1],
+      []
+    )
+    
+  def result_pattern(self, o, t):
+    pass
+
+class RemoveElementInputIndexPass(access_topo_drr.DrrPass):
+
+  def __init__(self, src_data_op_name, dst_load_from_global_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_load_from_global_op_name = pir.a_str(dst_load_from_global_op_name)
+
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op.name = self.src_data_op_name
+    o.src_data_op(
+      [],
+      [t.src_input]
+    )
+
+    o.dst_load_from_global_op = o.ap_native_op("ap_op.load_from_global")
+    o.dst_load_from_global_op.index_func_unique_id = self.dst_load_from_global_op_name
+    o.dst_load_from_global_op(
+      [t.dst_input],
+      [t.dst_load_from_global_output]
+    )
+    o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    o.up_spider_op(
+      [t.src_input, t.dst_load_from_global_output],
+      []
+    )
+
+  def result_pattern(self, o, t):
+    pass
+
+class RemoveBroadcastInputIndexPass(access_topo_drr.DrrPass):
+  def __init__(self, src_data_op_name, dst_load_from_global_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_load_from_global_op_name = pir.a_str(dst_load_from_global_op_name)
+
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op.name = self.src_data_op_name
+    o.src_data_op(
+      [],
+      [t.input0]
+    )
+    o.full_int_array_op = o.ap_native_op("pd_op.full_int_array")
+    o.full_int_array_op(
+      [],
+      [t.axis]
+    )
+    o.sum_op = o.ap_native_op("pd_op.sum")
+    o.sum_op(
+      [t.input0, t.axis],
+      [t.sum_out]
+    )
+    o.dst_load_from_global_op = o.ap_native_op("ap_op.load_from_global")
+    o.dst_load_from_global_op.index_func_unique_id = self.dst_load_from_global_op_name
+    o.dst_load_from_global_op(
+      [t.dst_input],
+      [t.dst_load_from_global_output]
+    )
+    o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    o.up_spider_op(
+      [t.sum_out, t.dst_load_from_global_output],
+      []
+    )
+    
+  def result_pattern(self, o, t):
+    pass
+
+class RemoveOutputIndexPass(access_topo_drr.DrrPass):
+
+  def __init__(self, src_data_op_name, dst_store_to_global_op_name):
+    self.src_data_op_name = pir.a_str(src_data_op_name)
+    self.dst_store_to_global_op_name = pir.a_str(dst_store_to_global_op_name)
+
+  def source_pattern(self, o, t):
+    o.src_data_op = o.ap_native_op("pd_op.data")
+    o.src_data_op.name = self.src_data_op_name
+    o.src_data_op(
+      [],
+      [t.src_input]
+    )
+    o.dst_store_to_global_op = o.ap_native_op("ap_op.store_to_global")
+    o.dst_store_to_global_op.index_func_unique_id = self.dst_store_to_global_op_name
+    o.dst_store_to_global_op(
+      [t.dst_output, t.dst_output_val],
+      []
+    )
+    o.up_spider_op = o.ap_native_op("ap_op.up_spider")
+    o.up_spider_op(
+      [t.src_input, t.dst_output_val],
+      []
+    )
+
+  def result_pattern(self, o, t):
+    pass
+
+@abstract_drr.register_drr_pass("matmul_ternary_fusion", nice=0)
+class MatmulTernaryFusion(abstract_drr.DrrPass):
+  def source_pattern(self, o, t):
+    o.matmul_op = o.ap_native_op("pd_op.matmul")
+    o.matmul_op(
+        [t.input0, t.input1],
+        [t.mm_out]
+    )
+
+    o.trivial_op = o.ap_trivial_fusion_op()
+    o.trivial_op(
+        [t.mm_out, t.input2, t.input3],
+        [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.fustion_op = o.ap_pattern_fusion_op(self.code_gen)
+    o.fustion_op([t.input0, t.input1, t.input2, t.input3], [t.output])
+
+  def constraint(self, o, t):
+    program = ir_tools.copy_fused_ops_to_program(o.trivial_op, tensor_match_ctx=t)
+    print("before-access_topo_pass", program)
+    init_pass_manager = ir_tools.create_pass_manager()
+    init_down_spider = topo_drr_pass.InitDownSpiderAccessTopoPass("mm_out")
+    init_pass_manager.add_pass(
+        ir_tools.create_access_topo_drr_one_step_pass(init_down_spider)
+    )
+    init_fake_data_for_yield_input = topo_drr_pass.FakeDataForYieldAccessTopoPass(
+      ["output"]
+    )
+    init_pass_manager.add_pass(
+        ir_tools.create_access_topo_drr_one_step_pass(init_fake_data_for_yield_input)
+    )
+    init_pass_manager.run(program)
+    print("after-init-access_topo_pass", program)
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("default"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("after-apply-access_topo_pass", program)
+    pass_manager = ir_tools.create_pass_manager()
+    # remove_data_op_pair_pass = RemoveDataOpPairPass(
+    #   src_data_op_name="mm_out",
+    #   dst_data_op_name="input2"
+    # )
+    # pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(
+    #   remove_data_op_pair_pass
+    # ))
+    # pass_manager.run(program)
+    # print("after-apply-RemoveDataOpPairPass_pass", program)
+    
+    remove_data_op2sum_op2data_op_pass = RemoveDataOp2SumOp2DataOpPass(
+      src_data_op_name="mm_out",
+      dst_data_op_name="input2"
+    #   dst_data_op_name2="input3"
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(
+      remove_data_op2sum_op2data_op_pass
+    ))
+    pass_manager.run(program)
+    print("after-apply-Removesuminput2_pass", program)
+
+    remove_data_op2sum_op2data_op_pass = RemoveDataOp2SumOp2DataOpPass(
+      src_data_op_name="mm_out",
+      dst_data_op_name="input3"
+    #   dst_data_op_name2="input3"
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(
+      remove_data_op2sum_op2data_op_pass
+    ))
+    pass_manager.run(program)
+    print("after-apply-Removesuminput3_pass", program)
+    remove_input3_pass = RemoveDataOpPairPass(
+      src_data_op_name="mm_out",
+      dst_data_op_name="input3"
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(remove_input3_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("after-remove-input3_pass", program)
+
+    remove_input3_pass = RemoveDataOpPairPass(
+      src_data_op_name="mm_out",
+      dst_data_op_name="input2"
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(remove_input3_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("after-remove-input2_pass", program)
+
+    remove_output_pass = RemoveDataOpPairPass(
+      src_data_op_name="mm_out",
+      dst_data_op_name="output"
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(remove_output_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("after-remove-input-output-access_topo_pass", program)
+    return program.empty()
+
+  def _insert_load_from_global(self, program, input_names):
+    init_pass_manager = ir_tools.create_pass_manager()
+    def AddPass(input_name):
+        ir_pass = topo_drr_pass.InitNaiveLoadFromGlobalAccessTopoPass(input_name)
+        init_pass_manager.add_pass(
+            ir_tools.create_access_topo_drr_one_step_pass(ir_pass)
+        )
+    map(AddPass, input_names)
+    init_pass_manager.run(program)
+
+  def _insert_store_to_global(self, program, output_names):
+    init_pass_manager = ir_tools.create_pass_manager()
+    ir_pass = topo_drr_pass.FakeDataStoreToGlobalForYieldAccessTopoPass(output_names)
+    init_pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(ir_pass))
+    init_pass_manager.run(program)
+
+  def _make_kernel_arg_translator(self):
+    return matmul_binary_tpl.make_kernel_arg_translator()
+
+  def _apply_topo_access_passes(self, mut_program, anchor_data_op_name):
+    init_pass_manager = ir_tools.create_pass_manager()
+    init_down_spider = topo_drr_pass.InitDownSpiderAccessTopoPass(anchor_data_op_name)
+    init_pass_manager.add_pass(
+        ir_tools.create_access_topo_drr_one_step_pass(init_down_spider)
+    )
+    init_pass_manager.run(mut_program)
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("default"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+
+  def _simplify_index_program(self, mut_program):
+    pass_manager = ir_tools.create_pass_manager()
+    drr_pass = topo_drr_pass.ConvertUpSpiderStoreDataOpToYieldOpPass()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    return mut_program
+
+  def _make_index_func_unique_id2index_program(
+          self, compute_program, anchor_data_op_name, input_names, output_names):
+    full_index_program = compute_program.clone()
+    self._apply_topo_access_passes(full_index_program, anchor_data_op_name)
+    def MatchAndCopyInputIndex(dst_input_name):
+        pass_manager = ir_tools.create_pass_manager()
+        removed_programs = MutableList()
+        rm_elementwise_drr_pass = RemoveElementInputIndexPass(
+            src_data_op_name=anchor_data_op_name,
+            dst_load_from_global_op_name=dst_input_name
+        )
+        rm_elementwise_ir_pass = ir_tools.create_access_topo_drr_one_step_pass(
+            rm_elementwise_drr_pass,
+            matched_pattern_mut_list=removed_programs
+        )
+        pass_manager.add_pass(rm_elementwise_ir_pass)
+        rm_broadcast_drr_pass = RemoveBroadcastInputIndexPass(
+            src_data_op_name=anchor_data_op_name,
+            dst_load_from_global_op_name=dst_input_name
+        )
+        rm_broadcast_ir_pass = ir_tools.create_access_topo_drr_one_step_pass(
+            rm_broadcast_drr_pass,
+            matched_pattern_mut_list=removed_programs
+        )
+        pass_manager.add_pass(rm_broadcast_ir_pass)
+        pass_manager.run(full_index_program)
+        def Converter(program):
+          return [dst_input_name, self._simplify_index_program(program)]
+        return map(Converter, removed_programs)
+    input_and_index_programs = flat_map(MatchAndCopyInputIndex, input_names)
+    def MatchAndCopyOutputIndex(dst_output_name):
+        pass_manager = ir_tools.create_pass_manager()
+        removed_programs = MutableList()
+        drr_pass = RemoveOutputIndexPass(
+            src_data_op_name=anchor_data_op_name,
+            dst_store_to_global_op_name=dst_output_name
+        )
+        ir_pass = ir_tools.create_access_topo_drr_one_step_pass(
+            drr_pass,
+            matched_pattern_mut_list=removed_programs
+        )
+        pass_manager.add_pass(ir_pass)
+        pass_manager.run(full_index_program)
+        def Converter(program):
+          return [dst_output_name, self._simplify_index_program(program)]
+        return map(Converter, removed_programs)
+    output_and_index_programs = flat_map(MatchAndCopyOutputIndex, output_names)
+    return OrderedDict([*input_and_index_programs, *output_and_index_programs])
+
+  def _replace_with_load_from_register(
+      self, mut_program, load_ir_value_name, register_var_name):
+    pass_manager = ir_tools.create_pass_manager()
+    drr_pass = topo_drr_pass.ReplaceWithLoadFromRegisterPass(
+        name=load_ir_value_name,
+        register_var_name=register_var_name
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    return mut_program
+
+  def _replace_with_store_to_register(
+      self, mut_program, store_ir_value_name, register_var_name):
+    pass_manager = ir_tools.create_pass_manager()
+    drr_pass = topo_drr_pass.ReplaceWithStoreToRegisterPass(
+        name=store_ir_value_name,
+        register_var_name=register_var_name
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    return mut_program
+
+  def _get_program_translator(self, ctx, o, t):
+    mut_program = ir_tools.copy_fused_ops_to_program(
+      o.trivial_op, tensor_match_ctx=t
+    )
+    self._insert_load_from_global(
+      mut_program,
+      input_names=["mm_out", "input2", "input3"]
+    )
+    self._insert_store_to_global(
+      mut_program,
+      output_names=["output"]
+    )
+    kernel_arg_translator = self._make_kernel_arg_translator()
+    index_func_unique_id2index_program = self._make_index_func_unique_id2index_program(
+      mut_program,
+      anchor_data_op_name="mm_out",
+      input_names=["input2", "input3"],
+      output_names=[],
+    )
+    print("index_func_unique_id2index_program:\n", index_func_unique_id2index_program)
+    index_program_translator_map = index_program_translator_util.IndexProgramTranslatorMap(
+      index_func_unique_id2index_program=index_func_unique_id2index_program,
+      kernel_arg_translator=kernel_arg_translator,
+      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names()
+    )
+    self._replace_with_load_from_register(
+      mut_program,
+      load_ir_value_name="mm_out",
+      register_var_name="x"
+    )
+    self._replace_with_store_to_register(
+      mut_program,
+      store_ir_value_name="output",
+      register_var_name="out"
+    )
+    print("mut_program:", mut_program)
+    op_compute_translator_maker = op_compute_translator_util.OpComputeTranslatorFactory()
+    program_translator = program_translator_util.ProgramTranslator(
+      program_property=mut_program.copy_to_const_program_data(),
+      kernel_arg_translator=kernel_arg_translator,
+      index_program_translator_map=index_program_translator_map,
+      op_translator_maker=op_compute_translator_maker
+    )
+    return program_translator
+
+  def code_gen(self, ctx, o, t):
+    program_translator = self._get_program_translator(ctx, o, t)
+    mut_kernel_arg_id_registry = kernel_arg_id_util.KernelArgIdNameRegistry(
+      code_gen_ctx=ctx,
+      tensor_match_ctx=t,
+      name_prefix=""
+    )
+    template_module = matmul_binary_tpl.MatmulBinaryTemplate(
+      program_translator=program_translator,
+      mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
+    )
+    def get_symbolic_shape_args_list(sym_dim):
+        return ctx.dim_expr_kernel_arg_id(sym_dim)
+    input0_shape_kargs = map(get_symbolic_shape_args_list, t.input0.symbolic_shape_to_list())
+    input1_shape_kargs = map(get_symbolic_shape_args_list, t.input1.symbolic_shape_to_list())
+    return template_module.compile(
+        input0_karg=ctx.in_tensor_data_ptr_kernel_arg_id(t.input0),
+        input1_karg=ctx.in_tensor_data_ptr_kernel_arg_id(t.input1),
+        output_karg=ctx.out_tensor_data_ptr_kernel_arg_id(t.output),
+        input0_shape_kargs=input0_shape_kargs,
+        input1_shape_kargs=input1_shape_kargs,
+    )
+

--- a/tests/ap/test_matmul_ternary.sh
+++ b/tests/ap/test_matmul_ternary.sh
@@ -1,0 +1,6 @@
+export CUDA_VISIBLE_DEVICES="2"
+export NVIDIA_TF32_OVERRIDE=0
+
+sh make_axpr.sh test_matmul_ternary
+
+FLAGS_enable_ap=1 AP_WORKSPACE_DIR=$(pwd)/ap_workspace AP_PATH=$(pwd)/ FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 FLAGS_cinn_bucket_compile=True FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True FLAGS_pir_apply_shape_optimization_pass=1 FLAGS_group_schedule_tiling_first=1 FLAGS_cinn_new_group_scheduler=1 python $(pwd)/paddle-tests/test_matmul_ternary.py

--- a/tests/ap/test_single_matmul.sh
+++ b/tests/ap/test_single_matmul.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -x
+export CUDA_VISIBLE_DEVICES="4"
+export NVIDIA_TF32_OVERRIDE=0
+sh make_axpr.sh test_matmul_epilogue
+FILE_NUM=$1
+LOG_DIR=$2
+TEST_DIR=/work/PaddleTest/framework/e2e/PaddleLT_new/layerE2Ecase/matmul-related-subgraphs/
+FILENAME=${TEST_DIR}/${FILE_NUM}.py
+
+export FLAGS_enable_ap=1
+export AP_WORKSPACE_DIR=$(pwd)/ap_workspace
+export AP_PATH=$(pwd)/
+export ATHENA_ENABLE_TRY_RUN=0
+export FLAGS_check_infer_symbolic=1
+export FLAGS_enable_pir_api=1
+export FLAGS_cinn_bucket_compile=True
+export FLAGS_prim_enable_dynamic=True
+export FLAGS_prim_all=True
+export FLAGS_pir_apply_shape_optimization_pass=1
+export FLAGS_group_schedule_tiling_first=1
+export FLAGS_cinn_new_group_scheduler=1
+# export FLAGS_cinn_enable_vectorize=true
+
+# export GLOG_v=6
+
+# export PATH=/opt/nvidia/nsight-systems/2023.4.1/bin:$PATH
+#nsys_args="nsys profile --stats true -w true -t cuda,nvtx,osrt,cudnn,cublas --capture-range=cudaProfilerApi -x true --force-overwrite true -o ${FILENAME}"
+touch tee "${LOG_DIR}/log_${FILE_NUM}.txt"
+GLOG_vmodule=ap_lower_fusion_op_pass=6 python $FILENAME 2>&1 | tee "${LOG_DIR}/log_${FILE_NUM}.txt"

--- a/tests/ap/topo_drr_pass.py
+++ b/tests/ap/topo_drr_pass.py
@@ -162,6 +162,32 @@ class ConvertUpSpiderStoreDataOpToYieldOpPass(access_topo_drr.DrrPass):
       []
     )
 
+class ConvertDownSpiderStoreDataOpToYieldOpPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.data_mm_op = o.ap_native_op("pd_op.data")
+    o.data_mm_op(
+      [],
+      [t.input1]
+    )
+    o.down_spider_op = o.ap_native_op("ap_op.down_spider")
+    o.down_spider_op(
+      [t.input1],
+      [t.tmp1]
+    )
+    o.store_to_global = o.ap_native_op("ap_op.store_to_global")
+    o.store_to_global(
+      [t.input0, t.tmp1],
+      []
+    )
+
+  def result_pattern(self, o, t):
+    o.yield_op = o.ap_native_op("cf.yield")
+    o.yield_op(
+      [t.input0],
+      []
+    )
+
 class InitDownSpiderAccessTopoPass(access_topo_drr.DrrPass):
 
   def __init__(self, data_input_name):
@@ -354,7 +380,7 @@ class DownSpiderUpSpiderAccessTopoPass(access_topo_drr.DrrPass):
     pass
 
 
-@access_topo_drr.register_drr_pass("down_spider_add", tag="default")
+@access_topo_drr.register_drr_pass("left_down_spider_add", tag="default")
 class DownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):
@@ -381,6 +407,32 @@ class DownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
       []
     )
 
+@access_topo_drr.register_drr_pass("right_down_spider_add", tag="default")
+class DownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.spider = o.ap_native_op("ap_op.down_spider")
+    o.spider(
+      [t.input0],
+      [t.tmp0]
+    )
+    o.add = o.ap_native_op("pd_op.add")
+    o.add(
+      [t.tmp1, t.tmp0],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.down_spider = o.ap_native_op("ap_op.down_spider")
+    o.down_spider(
+      [t.input0],
+      [t.output]
+    )
+    o.up_spider = o.ap_native_op("ap_op.up_spider")
+    o.up_spider(
+      [t.tmp1, t.input0],
+      []
+    )
 
 @access_topo_drr.register_drr_pass("expand_up_spider", tag="default")
 class ExpandUpSpiderAccessTopoPass(access_topo_drr.DrrPass):

--- a/tests/ap/umprime.py
+++ b/tests/ap/umprime.py
@@ -1,0 +1,66 @@
+import access_topo_drr
+import pir
+
+@access_topo_drr.register_drr_pass("pd_op_static_relu", tag="umprime")
+class PdOpCastAccessTopoPass(access_topo_drr.DrrPass):
+  def __init__(self):
+    self.zero = pir.a_f64(DataValue.float64("0"))
+
+  def source_pattern(self, o, t):
+    o.full_op = o.ap_native_op("pd_op.full")
+    o.full_op(
+      [],
+      [t.intermediate]
+    )
+    o.maximum_op = o.ap_native_op("pd_op.maximum")
+    o.maximum_op(
+      [t.input, t.intermediate],
+      [t.output]
+    )
+  def constraint(self, o, t):
+    return o.full_op.value == self.zero
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
+      [t.input],
+      [t.output]
+    )
+
+
+@access_topo_drr.register_drr_pass("pd_op_dynamic_relu", tag="umprime")
+class PdOpCastAccessTopoPass(access_topo_drr.DrrPass):
+  def __init__(self):
+    self.zero = pir.a_f64(DataValue.float64("0"))
+
+  def source_pattern(self, o, t):
+    o.full_op = o.ap_native_op("pd_op.full")
+    o.full_op(
+      [],
+      [t.intermediate0]
+    )
+    o.generate_shape_op = o.ap_native_op("cinn_op.generate_shape")
+    o.generate_shape_op(
+      [t.input0],
+      [t.intermediate1]
+    )
+    o.expand_op = o.ap_native_op("pd_op.expand")
+    o.expand_op(
+      [t.intermediate0, t.intermediate1],
+      [t.intermediate2]
+    )
+    o.maximum_op = o.ap_native_op("pd_op.maximum")
+    o.maximum_op(
+      [t.input1, t.intermediate2],
+      [t.output]
+    )
+  def constraint(self, o, t):
+    return o.full_op.value == self.zero
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
+      [t.input1],
+      [t.output]
+    )
+


### PR DESCRIPTION
# Features
1. Support the cases of matmul + ternary operation.
2. Support the arbitrary inputs/outputs
3. Support non-3-dim mm_out
4. Support dynamic relu by reprime
5. Support the batch testing and analysis of the PaddleTest.
6. Rename test_matmul_binary_outs to test_matmul_epilogue
7. Exact the remove-function classes from the main pattern `MatmulEpilogueFusion`


## Example for feature 1:
```
Eg: out = matmul(x,y) - b +c
```

Generated code:
```
template <typename T>
struct VariadicEpilogueFunctor {
  struct Arguments {
    ...
    const half* in_ptr_1;
  };

  // Note: need to support vectorized operation
  __forceinline__ __host__ __device__
  T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
    T out;
    float op1_out0 = static_cast<float>(args.in_ptr_0[(coord.row * args.input0_dim2 + coord.column)]);
    ...};
```


## Example for feature 2:
```
bash test_matmul_epilogue.sh
```

## Key idea for feature 3: 
`PdOpSumCodeGen` and `CinnOpReshapeCodeGen` in `op_index_translator_util.py`

## Key idea for feature 4: 
See `umprime.py`

## Example for feature 5: 
### Batch test
`python test_all_matmul_graphs.py`
 The log will be stored in /workspace/Athena/tests/ap/ap_matmul_graphs/2025-03-19_20:56:02

### Unit test: 
`bash test_single_matmul.sh file_name temp` 
The log will be stored in temp

### coverage analysis
`python test_ap_coverage_rate.py`

## File for feature 7: 
`matmul_epilogue_remove_pass.py`

