### PR TITLE
Allow setting alignment according the value of m, n, k.

### DIFF
--- a/tests/ap/matmul/cutlass_matmul.cuh
+++ b/tests/ap/matmul/cutlass_matmul.cuh
@@ -67,7 +67,7 @@ cutlass::Status SetMaxDynamicSharedMemorySize() {
     CUTLASS_TRACE_HOST("cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags() returned error " << cudaGetErrorString(cudart_result));
     return cutlass::Status::kErrorInternal;
   }
-  CUTLASS_TRACE_HOST("sm_occupancy: (" << sm_occupancy_ << ") "
+  CUTLASS_TRACE_HOST("sm_occupancy: (" << sm_occupancy << ") "
       "smem_size: (" << GemmFunc::kSharedStorageSize << ") "
       "GemmKernel::kThreadCount: (" << GemmFunc::GemmKernel::kThreadCount << ")");
 #endif
@@ -391,6 +391,8 @@ void CutlassMatmulAddBroadcast(const GemmBroadcastEpilogueParams& params) {
 template <typename ElementT,
           typename ElementComputeT,
           template<typename T> class VariadicFunctor,
+          int AlignA = 128 / cutlass::sizeof_bits<ElementT>::value,
+          int AlignB = 128 / cutlass::sizeof_bits<ElementT>::value,
           int ConfigId = DefaultConfig::kConfigId,
           int SwizzleFactor = DefaultConfig::kSwizzleFactor,
           bool Batched = DefaultConfig::kBatched>
@@ -401,12 +403,14 @@ void CutlassMatmulAddVariadic(const GemmEpilogueParams& params, const typename V
   using ElementInputB = typename CutlassDataType<ElementT>::Type; // <- data type of elements in input matrix B
   using ElementOutput = typename CutlassDataType<ElementT>::Type;// <- data type of elements in output matrix D
 
+  constexpr int AlignC = AlignB;
+
   // Epilogue operation as LinearCombination:
   //  alpha * accumulator + beta * source
   using EpilogueOutputOp = cutlass::epilogue::thread::LinearCombinationVariadic<
       VariadicFunctor,
       ElementOutput,
-      128 / cutlass::sizeof_bits<ElementOutput>::value,
+      AlignC,
       ElementAccumulator,
       ElementComputeEpilogue,
       cutlass::epilogue::thread::ScaleType::NoBetaScaling>; // <- alpha x AB + bias
@@ -427,9 +431,9 @@ void CutlassMatmulAddVariadic(const GemmEpilogueParams& params, const typename V
       EpilogueOutputOp,
       typename GemmTuningConfigs<ElementT, SwizzleFactor, Batched, ConfigId>::SwizzleThreadBlock,
       GemmTuningConfigs<ElementT, SwizzleFactor, Batched, ConfigId>::kNumStages,
-      128 / cutlass::sizeof_bits<ElementInputA>::value, // AlignA
-      128 / cutlass::sizeof_bits<ElementInputB>::value, // AlignB
-      typename GemmOperation<ElementT>::Type  // Operation performed by GEMM
+      AlignA,
+      AlignB,
+      typename GemmOperation<ElementT>::Type
   >;
 
   CHECK_CUTLASS(SetMaxDynamicSharedMemorySize<GemmFunc>());

--- a/tests/ap/matmul/matmul.h
+++ b/tests/ap/matmul/matmul.h
@@ -45,6 +45,12 @@
     }                                                                          \
   } while (0)
 
+#define AP_ALIGNMENT_half(d) \
+  ((d % 8) == 0) ? 8 : (((d % 4) == 0) ? 4 : (((d % 2) == 0) ? 2: 1))
+
+#define AP_ALIGNMENT_float(d) \
+  ((d % 4) == 0) ? 4 : (((d % 2) == 0) ? 2: 1)
+
 namespace ap {
 
 template <typename T, int N> using Array = cutlass::Array<T, N>;

--- a/tests/ap/matmul/tests/matmul_binary_kernel.cu
+++ b/tests/ap/matmul/tests/matmul_binary_kernel.cu
@@ -36,8 +36,11 @@ static void RunMatmulAddBinaryKernel(const GemmEpilogueParams &params) {
         reinterpret_cast<const ElementT *>(params.epilogue_in_ptrs[0]);
   }
 
+  constexpr int AlignA = 128 / cutlass::sizeof_bits<ElementT>::value;
+  constexpr int AlignB = 2;
   CutlassMatmulAddVariadic<ElementT, ElementComputeT, VariadicEpilogueFunctor,
-                           TuningConfigId>(params, variadic_args);
+                           AlignA, AlignB, TuningConfigId>(params,
+                                                           variadic_args);
 }
 
 void MatmulAddBinaryKernel(

--- a/tests/ap/matmul/tests/matmul_binary_kernel.cu
+++ b/tests/ap/matmul/tests/matmul_binary_kernel.cu
@@ -37,7 +37,7 @@ static void RunMatmulAddBinaryKernel(const GemmEpilogueParams &params) {
   }
 
   constexpr int AlignA = 128 / cutlass::sizeof_bits<ElementT>::value;
-  constexpr int AlignB = 2;
+  constexpr int AlignB = 128 / cutlass::sizeof_bits<ElementT>::value;
   CutlassMatmulAddVariadic<ElementT, ElementComputeT, VariadicEpilogueFunctor,
                            AlignA, AlignB, TuningConfigId>(params,
                                                            variadic_args);

--- a/tests/ap/matmul_binary_tpl.py
+++ b/tests/ap/matmul_binary_tpl.py
@@ -219,14 +219,17 @@ void MatmulBinaryKernel(void* stream_ptr, AP_KERNEL_ARGS_DECLARE) {
   ap::GemmEpilogueParams params(
       *cuda_stream_ptr, $input0, $input1, nullptr, $output, $input0_shape, $input1_shape, std::vector<int64_t>{});
 
-  using ElementT = AP_GENERATED_ELEMENT_DTYPE;
+  using ElementT = ${output_dtype};
   using ElementComputeT = float;
 
   typename ap::VariadicEpilogueFunctor<ElementComputeT>::Arguments epilogue_args;
 
   AP_EPILOGUE_ARGUMENTS_INIT
 
-  ap::CutlassMatmulAddVariadic<ElementT, ElementComputeT, ap::VariadicEpilogueFunctor>(params, epilogue_args);
+  constexpr int AlignA = AP_ALIGNMENT_${output_dtype}(${k_value});
+  constexpr int AlignB = AP_ALIGNMENT_${output_dtype}(${n_value});
+
+  ap::CutlassMatmulAddVariadic<ElementT, ElementComputeT, ap::VariadicEpilogueFunctor, AlignA, AlignB>(params, epilogue_args);
 }
 }
 
@@ -237,7 +240,6 @@ void MatmulBinaryKernel(void* stream_ptr, AP_KERNEL_ARGS_DECLARE) {
             code_template.replace(
                 "AP_GENERATED_BINARY_EPILOGUE_STRING", trivial_code_str
             )
-            .replace("AP_GENERATED_ELEMENT_DTYPE", output_dtype)
             .replace("AP_KERNEL_ARGS_DECLARE", self.get_kernel_arg_list_str())
             .replace(
                 "AP_INPUT0_SHAPE_INIT",
@@ -257,6 +259,9 @@ void MatmulBinaryKernel(void* stream_ptr, AP_KERNEL_ARGS_DECLARE) {
             .replace("$input0", self.get_kernel_arg_id_var_name(input0_karg))
             .replace("$input1", self.get_kernel_arg_id_var_name(input1_karg))
             .replace("$output", self.get_kernel_arg_id_var_name(output_karg))
+            .replace("${output_dtype}", output_dtype)
+            .replace("${k_value}", f"{input0_shape_kargs[-1].value}")
+            .replace("${n_value}", f"{input1_shape_kargs[-1].value}")
         )
 
         source_dir = "/work/abstract_pass/Athena/tests/ap/matmul"


### PR DESCRIPTION
cutlass中会依据传入的Alignment参数，对矩阵进行向量化的访问，以加速显存数据的读写。当前实现中Alignment值设置成固定的`128 / cutlass::sizeof_bits<ElementI>::value`，当实际数据不满足要求时，会出现如下错误：
```
Got cutlass error: Error Misaligned Operand at: 472
malloc_consolidate(): invalid chunk size
```

一般来说，矩阵的首地址是满足对齐要求的，实际的Alignment由矩阵的leading dimension决定。本PR对此进行修复。注意，为了减少编译时间，用了输入维度的值来计算`AlignA`、`AlignB`，这样计算得到的`AlignA`、`AlignB`可以直接用于模板中。