### PR TITLE
Enable autotune in AP generated kernels.

### DIFF
--- a/tests/ap/make_axpr.sh
+++ b/tests/ap/make_axpr.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 
-TEST_FILENAME=${1:-"test_trivial_reduce"}
-#TEST_FILENAME=${1:-"test_matmul_unary"}
-
-TEST_TPL_FILENAME=`echo ${TEST_FILENAME/test_/}`
-
-echo "-- Write 'import ${TEST_FILENAME}' to __main__.py"
-echo "import ${TEST_FILENAME}" > __main__.py
-
-
 FILENAMES_ARRAY=(
     "index_code_gen_value_util"
     "index_drr_pass_util"
@@ -26,8 +17,8 @@ FILENAMES_ARRAY=(
     "access_topo_drr"
     "abstract_drr"
     "ap_tpl_codegen"
-    "${TEST_FILENAME}"
-    "${TEST_TPL_FILENAME}_tpl"
+    "matmul_binary_tpl"
+    "test_matmul_binary"
 )
 for filename in "${FILENAMES_ARRAY[@]}"
 do

--- a/tests/ap/matmul/all_tuning_configs.h
+++ b/tests/ap/matmul/all_tuning_configs.h
@@ -20,30 +20,30 @@ template <int SwizzleFactor, bool Batched> struct SwizzleWrapper {
 //       cutlass::gemm::threadblock::GemmBatchedIdentityThreadblockSwizzle;
 // };
 
-#define AP_AUTOTUNE_FP16(func)                                                 \
+#define AP_AUTOTUNE_half(func)                                                 \
   {                                                                            \
     static int selected_config_id = -1;                                        \
-    static std::vector<std::function<void(const GemmEpilogueParams &)>>        \
+    static std::vector<std::function<void(const ap::GemmEpilogueParams &)>>    \
         matmul_functions = {func<0>,  func<1>,  func<2>,  func<3>,  func<4>,   \
                             func<5>,  func<6>,  func<7>,  func<8>,  func<9>,   \
                             func<10>, func<11>, func<12>, func<13>, func<14>,  \
                             func<15>, func<16>, func<17>, func<18>, func<19>,  \
                             func<20>, func<21>, func<22>};                     \
     if (selected_config_id == -1) {                                            \
-      selected_config_id = ProfileBestConfig(matmul_functions, params);        \
+      selected_config_id = ap::ProfileBestConfig(matmul_functions, params);    \
     }                                                                          \
     matmul_functions[selected_config_id](params);                              \
   }
 
-#define AP_AUTOTUNE_FP32(func)                                                 \
+#define AP_AUTOTUNE_float(func)                                                \
   {                                                                            \
     static int selected_config_id = -1;                                        \
-    static std::vector<std::function<void(const GemmEpilogueParams &)>>        \
+    static std::vector<std::function<void(const ap::GemmEpilogueParams &)>>    \
         matmul_functions = {func<0>,  func<1>,  func<2>, func<3>, func<4>,     \
                             func<5>,  func<6>,  func<7>, func<8>, func<9>,     \
                             func<10>, func<11>, func<12>};                     \
     if (selected_config_id == -1) {                                            \
-      selected_config_id = ProfileBestConfig(matmul_functions, params);        \
+      selected_config_id = ap::ProfileBestConfig(matmul_functions, params);    \
     }                                                                          \
     matmul_functions[selected_config_id](params);                              \
   }

--- a/tests/ap/matmul/matmul.h
+++ b/tests/ap/matmul/matmul.h
@@ -45,11 +45,10 @@
     }                                                                          \
   } while (0)
 
-#define AP_ALIGNMENT_half(d) \
-  ((d % 8) == 0) ? 8 : (((d % 4) == 0) ? 4 : (((d % 2) == 0) ? 2: 1))
+#define AP_ALIGNMENT_half(d)                                                   \
+  ((d % 8) == 0) ? 8 : (((d % 4) == 0) ? 4 : (((d % 2) == 0) ? 2 : 1))
 
-#define AP_ALIGNMENT_float(d) \
-  ((d % 4) == 0) ? 4 : (((d % 2) == 0) ? 2: 1)
+#define AP_ALIGNMENT_float(d) ((d % 4) == 0) ? 4 : (((d % 2) == 0) ? 2 : 1)
 
 namespace ap {
 
@@ -87,6 +86,8 @@ struct GemmEpilogueParams {
 
   cudaStream_t stream;
 
+  std::vector<int64_t> input0_shape;
+  std::vector<int64_t> input1_shape;
   std::vector<const void *> epilogue_in_ptrs;
   std::vector<std::vector<int64_t>> epilogue_in_shapes;
 
@@ -101,6 +102,9 @@ struct GemmEpilogueParams {
         output(output), transpose_a(transpose_a), transpose_b(transpose_b) {
     ASSERT_CHECK(input_shape.size() >= 2U);
     ASSERT_CHECK(weight_shape.size() >= 2U);
+
+    input0_shape = input_shape;
+    input1_shape = weight_shape;
 
     batch_count = 1;
     for (size_t i = 0; i < input_shape.size() - 2; ++i) {
@@ -152,8 +156,13 @@ struct GemmEpilogueParams {
     shape_args.ldc_bias = (!bias || is_C_bias) ? 0 : n;
   }
 
-  void SetEpilogues(const std::vector<const void *> &in_ptrs,
-                    const std::vector<std::vector<int64_t>> &in_shapes) {
+  void SetEpilogues(const std::vector<const void *> &in_ptrs) {
+    epilogue_in_ptrs = in_ptrs;
+  }
+
+  void
+  SetEpilogueAndShapes(const std::vector<const void *> &in_ptrs,
+                       const std::vector<std::vector<int64_t>> &in_shapes) {
     ASSERT_CHECK(in_ptrs.size() == in_shapes.size());
     epilogue_in_ptrs = in_ptrs;
     epilogue_in_shapes = in_shapes;

--- a/tests/ap/matmul/profile.h
+++ b/tests/ap/matmul/profile.h
@@ -54,8 +54,8 @@ static int ProfileBestConfig(
             << params.batch_count << ", " << params.m << ", " << params.n
             << ", " << params.k << "}" << std::endl;
 
-  constexpr int kWarmupIters = 10;
-  constexpr int kRepeatIters = 1000;
+  constexpr int kWarmupIters = 1;
+  constexpr int kRepeatIters = 100;
 
   GpuTimer gpu_timer(false);
   float min_time_ms = 100000.f;

--- a/tests/ap/matmul/tests/matmul_binary_kernel.cu
+++ b/tests/ap/matmul/tests/matmul_binary_kernel.cu
@@ -53,13 +53,13 @@ void MatmulAddBinaryKernel(
     const std::vector<std::vector<int64_t>> &epilogue_shapes) {
   GemmEpilogueParams params(*stream, input, weight, bias, output, input_shape,
                             weight_shape, bias_shape);
-  params.SetEpilogues(epilogue_ins, epilogue_shapes);
+  params.SetEpilogueAndShapes(epilogue_ins, epilogue_shapes);
 
-#if AP_ENABLE_AUTO_TUNING
+#if AP_ENABLE_AUTOTUNE
 #if AP_USE_FLOAT16
-  AP_AUTOTUNE_FP16(RunMatmulAddBinaryKernel);
+  AP_AUTOTUNE_half(RunMatmulAddBinaryKernel);
 #else
-  AP_AUTOTUNE_FP32(RunMatmulAddBinaryKernel);
+  AP_AUTOTUNE_float(RunMatmulAddBinaryKernel);
 #endif
 #else
   RunMatmulAddBinaryKernel<DefaultConfig::kConfigId>(params);

--- a/tests/ap/matmul/tests/matmul_kernel.cu
+++ b/tests/ap/matmul/tests/matmul_kernel.cu
@@ -32,11 +32,11 @@ void MatmulKernel(cudaStream_t *stream, const void *input, const void *weight,
                             input_shape, weight_shape, std::vector<int64_t>{},
                             false, transpose_b);
 
-#if AP_ENABLE_AUTO_TUNING
+#if AP_ENABLE_AUTOTUNE
 #if AP_USE_FLOAT16
-  AP_AUTOTUNE_FP16(RunMatmulKernel);
+  AP_AUTOTUNE_half(RunMatmulKernel);
 #else
-  AP_AUTOTUNE_FP32(RunMatmulKernel);
+  AP_AUTOTUNE_float(RunMatmulKernel);
 #endif
 #else
   RunMatmulKernel<DefaultConfig::kConfigId>(params);

--- a/tests/ap/matmul/tests/matmul_unary_kernel.cu
+++ b/tests/ap/matmul/tests/matmul_unary_kernel.cu
@@ -41,11 +41,11 @@ void MatmulAddUnaryKernel(cudaStream_t *stream, const void *input,
   GemmEpilogueParams params(*stream, input, weight, bias, output, input_shape,
                             weight_shape, bias_shape, false, transpose_b);
 
-#if AP_ENABLE_AUTO_TUNING
+#if AP_ENABLE_AUTOTUNE
 #if AP_USE_FLOAT16
-  AP_AUTOTUNE_FP16(RunMatmulAddUnaryKernel);
+  AP_AUTOTUNE_half(RunMatmulAddUnaryKernel);
 #else
-  AP_AUTOTUNE_FP32(RunMatmulAddUnaryKernel);
+  AP_AUTOTUNE_float(RunMatmulAddUnaryKernel);
 #endif
 #else
   RunMatmulAddUnaryKernel<DefaultConfig::kConfigId>(params);

--- a/tests/ap/matmul_binary_tpl.py
+++ b/tests/ap/matmul_binary_tpl.py
@@ -10,6 +10,11 @@ def get_anchor_iter_var_names():
     return ["coord.batch", "coord.row", "coord.column"]
 
 
+def is_in_tensor_karg(kernel_arg_id):
+    kernel_arg_id_type_name = f"{type(kernel_arg_id)}".replace("<class '", "").replace("'>", "")
+    return kernel_arg_id_type_name == "InTensorDataPtrKernelArgId"
+
+
 class MatmulBinaryTemplate:
     def __init__(
         self,
@@ -30,6 +35,10 @@ class MatmulBinaryTemplate:
                 [DataType.int64_t, "int64_t"],
             ]
         )
+        self.input_dim_karg_to_shape_access = MutableOrderedDict()
+        self.input_tensor_karg_to_shape_access = MutableOrderedDict()
+        self.kernel_name = "MatmulBinaryKernel"
+        self.library_name = "matmul_binary_kernel"
 
     def _register_name(self, pair):
         registry = self.mut_kernel_arg_id_registry
@@ -142,14 +151,23 @@ class MatmulBinaryTemplate:
             map(declare_epilogue_arguments_field, generated_kernel_arg_id_and_names)
         )
 
-    def get_epilogue_arguments_init_str(self, param_obj_name, indent):
+    def get_epilogue_arguments_init_str(self, obj_name, params_name, output_dtype, indent):
         def declare_epilogue_arguments_assign(pair):
             kernel_arg_id = pair[0]
+            is_in_tensor_type = is_in_tensor_karg(kernel_arg_id)
+
             var_name = pair[1]
             field_name = self.kernel_arg_translator.get_param_struct_field_name(
                 var_name
             )
-            return f"{param_obj_name}.{field_name} = {var_name};"
+            def get_in_tensor_statement():
+                param_name_for_var = self.input_tensor_karg_to_shape_access[var_name]
+                return f"reinterpret_cast<const {output_dtype} *>({params_name}.{param_name_for_var})"
+            def get_dim_expr_statement():
+                param_name_for_var = self.input_dim_karg_to_shape_access[var_name]
+                return f"{params_name}.{param_name_for_var}"
+            statement = get_in_tensor_statement() if is_in_tensor_type else get_dim_expr_statement()
+            return f"{obj_name}.{field_name} = {statement};"
 
         generated_kernel_arg_id_and_names = (
             self.mut_kernel_arg_id_registry.generated_kernel_arg_id2unique_name.items()
@@ -158,10 +176,35 @@ class MatmulBinaryTemplate:
             map(declare_epilogue_arguments_assign, generated_kernel_arg_id_and_names)
         )
 
-    def get_input_shape_init_str(self, input_name, input_shape_kargs, indent):
+    def get_params_epilogue_ptrs_init_str(self, obj_name, indent):
+        in_tensor_id = 0
+        def declare_params_epilogue_arguments_assign(pair):
+            def get_creator():
+                return f"{obj_name}[{in_tensor_id}]"
+
+            kernel_arg_id = pair[0]
+            is_in_tensor_type = is_in_tensor_karg(kernel_arg_id)
+            def generate_statement():
+                self.input_tensor_karg_to_shape_access.get_or_create(pair[1], get_creator)
+                statement = f"{obj_name}.push_back({pair[1]});"
+                in_tensor_id = in_tensor_id + 1
+                return statement
+            return generate_statement() if is_in_tensor_type else ""
+
+        generated_kernel_arg_id_and_names = (
+            self.mut_kernel_arg_id_registry.generated_kernel_arg_id2unique_name.items()
+        )
+        return f"\n{indent}".join(
+            map(declare_params_epilogue_arguments_assign, generated_kernel_arg_id_and_names)
+        )
+
+    def get_params_input_shape_init_str(self, input_name, input_shape_kargs, indent):
         def init_input_shape_with_args(i):
-            karg = input_shape_kargs[i]
-            return f"{indent}{input_name}_shape[{i}] = {self.get_kernel_arg_id_var_name(karg)};"
+            def get_creator():
+                return f"{input_name}_shape[{i}]"
+            karg_var_name = self.get_kernel_arg_id_var_name(input_shape_kargs[i])
+            self.input_dim_karg_to_shape_access.get_or_create(karg_var_name, get_creator)
+            return f"{indent}{input_name}_shape[{i}] = {karg_var_name};"
 
         shape_vector_init_str = (
             f"{input_name}_shape.resize({len(input_shape_kargs)});\n"
@@ -186,6 +229,7 @@ class MatmulBinaryTemplate:
 #include <vector>
 
 #include "cutlass_matmul.cuh"
+#include "profile.h"
 
 namespace ap {
 
@@ -204,35 +248,50 @@ struct VariadicEpilogueFunctor {
   }
 };
 
-}
-
-extern "C" {
-
-void MatmulBinaryKernel(void* stream_ptr, AP_KERNEL_ARGS_DECLARE) {
-  std::vector<int64_t> $input0_shape;
-  AP_INPUT0_SHAPE_INIT
-
-  std::vector<int64_t> $input1_shape;
-  AP_INPUT1_SHAPE_INIT
-
-  cudaStream_t* cuda_stream_ptr = reinterpret_cast<cudaStream_t*>(stream_ptr);
-  ap::GemmEpilogueParams params(
-      *cuda_stream_ptr, $input0, $input1, nullptr, $output, $input0_shape, $input1_shape, std::vector<int64_t>{});
-
+template <int TuningConfigId>
+static void RunMatmulWithVariadicKernel(const GemmEpilogueParams &params) {
   using ElementT = ${output_dtype};
   using ElementComputeT = float;
 
-  typename ap::VariadicEpilogueFunctor<ElementComputeT>::Arguments epilogue_args;
+  typename VariadicEpilogueFunctor<ElementComputeT>::Arguments epilogue_args;
 
   AP_EPILOGUE_ARGUMENTS_INIT
 
   constexpr int AlignA = AP_ALIGNMENT_${output_dtype}(${k_value});
   constexpr int AlignB = AP_ALIGNMENT_${output_dtype}(${n_value});
 
-  ap::CutlassMatmulAddVariadic<ElementT, ElementComputeT, ap::VariadicEpilogueFunctor, AlignA, AlignB>(params, epilogue_args);
-}
+  CutlassMatmulAddVariadic<ElementT, ElementComputeT, VariadicEpilogueFunctor,
+                           AlignA, AlignB, TuningConfigId>(params,
+                                                           epilogue_args);
 }
 
+} // namespace ap
+
+extern "C" {
+
+void ${kernel_name}(void* stream_ptr, AP_KERNEL_ARGS_DECLARE) {
+  std::vector<int64_t> ${input0}_shape;
+  AP_PARAMS_INPUT0_SHAPE_INIT
+
+  std::vector<int64_t> ${input1}_shape;
+  AP_PARAMS_INPUT1_SHAPE_INIT
+
+  cudaStream_t* cuda_stream_ptr = reinterpret_cast<cudaStream_t*>(stream_ptr);
+  ap::GemmEpilogueParams params(
+      *cuda_stream_ptr, ${input0}, ${input1}, nullptr, ${output}, ${input0}_shape, ${input1}_shape, std::vector<int64_t>{});
+
+  std::vector<const void *> epilogue_in_ptrs;
+  AP_PARAMS_EPILOGUE_PTRS_INIT
+
+  params.SetEpilogues(epilogue_in_ptrs);
+
+#if AP_ENABLE_AUTOTUNE
+  AP_AUTOTUNE_${output_dtype}(ap::RunMatmulWithVariadicKernel);
+#else
+  ap::RunMatmulWithVariadicKernel<ap::DefaultConfig::kConfigId>(params);
+#endif
+}
+}
   """
 
         output_dtype = self.dtype2type_name[output_karg.type.data_type]
@@ -242,26 +301,29 @@ void MatmulBinaryKernel(void* stream_ptr, AP_KERNEL_ARGS_DECLARE) {
             )
             .replace("AP_KERNEL_ARGS_DECLARE", self.get_kernel_arg_list_str())
             .replace(
-                "AP_INPUT0_SHAPE_INIT",
-                self.get_input_shape_init_str("$input0", input0_shape_kargs, indent="  "),
+                "AP_PARAMS_INPUT0_SHAPE_INIT",
+                self.get_params_input_shape_init_str("${input0}", input0_shape_kargs, indent="  "),
             )
             .replace(
-                "AP_INPUT1_SHAPE_INIT",
-                self.get_input_shape_init_str("$input1", input1_shape_kargs, indent="  "),
+                "AP_PARAMS_INPUT1_SHAPE_INIT",
+                self.get_params_input_shape_init_str("${input1}", input1_shape_kargs, indent="  "),
+            )
+            .replace(
+                "AP_PARAMS_EPILOGUE_PTRS_INIT",
+                self.get_params_epilogue_ptrs_init_str("epilogue_in_ptrs", indent="  "),
             )
             .replace(
                 "AP_EPILOGUE_ARGUMENTS_FIELDS", self.get_epilogue_arguments_fields_str(indent="    ")
             )
             .replace(
                 "AP_EPILOGUE_ARGUMENTS_INIT",
-                self.get_epilogue_arguments_init_str("epilogue_args", indent="  "),
+                self.get_epilogue_arguments_init_str("epilogue_args", "params", output_dtype, indent="  "),
             )
-            .replace("$input0", self.get_kernel_arg_id_var_name(input0_karg))
-            .replace("$input1", self.get_kernel_arg_id_var_name(input1_karg))
-            .replace("$output", self.get_kernel_arg_id_var_name(output_karg))
+            .replace("${kernel_name}", self.kernel_name)
+            .replace("${input0}", self.get_kernel_arg_id_var_name(input0_karg))
+            .replace("${input1}", self.get_kernel_arg_id_var_name(input1_karg))
+            .replace("${output}", self.get_kernel_arg_id_var_name(output_karg))
             .replace("${output_dtype}", output_dtype)
-            .replace("${k_value}", f"{input0_shape_kargs[-1].value}")
-            .replace("${n_value}", f"{input1_shape_kargs[-1].value}")
         )
 
         source_dir = "/work/abstract_pass/Athena/tests/ap/matmul"
@@ -274,26 +336,27 @@ void MatmulBinaryKernel(void* stream_ptr, AP_KERNEL_ARGS_DECLARE) {
         compile_cmd = compile_cmd + " -I " + source_dir
         compile_cmd = (
             compile_cmd
-            + " -DCUTLASS_ENABLE_TENSOR_CORE_MMA=1 -DCUTLASS_DEBUG_TRACE_LEVEL=0 "
+            + " -DCUTLASS_ENABLE_TENSOR_CORE_MMA=1 -DCUTLASS_DEBUG_TRACE_LEVEL=0"
         )
+        compile_cmd = compile_cmd + " -DAP_ENABLE_AUTOTUNE=1 -DAP_ENABLE_DEBUG=0"
         compile_cmd = (
             compile_cmd
-            + " --shared matmul_binary_kernel.cu -o libmatmul_binary_kernel.so"
+            + f" --shared {self.library_name}.cu -o lib{self.library_name}.so"
         )
 
         return CodeModule(
             FuncDeclare(
                 DataType.void,
-                "MatmulBinaryKernel",
+                self.kernel_name,
                 [PointerType.void_ptr, *self.get_kernel_arg_types()],
             ),
             Project(
                 nested_files=Project.Directory(
-                    ["matmul_binary_kernel.cu", Project.FileContent(code)],
+                    [f"{self.library_name}.cu", Project.FileContent(code)],
                     ["make.sh", Project.FileContent(compile_cmd)],
                 ),
                 compile_cmd="sh make.sh",
-                so_relative_path="libmatmul_binary_kernel.so",
+                so_relative_path=f"lib{self.library_name}.so",
             ),
         )
 

--- a/tests/ap/paddle-tests/test_matmul_binary.py
+++ b/tests/ap/paddle-tests/test_matmul_binary.py
@@ -18,20 +18,21 @@ from os.path import dirname
 sys.path.append(dirname(__file__))
 
 import unittest
-
 import utils
 
 import paddle
 from paddle.static import InputSpec
 
 
-def trivial_matrix_binary(x, y, b):
+def matmul_add_relu(x, y, b):
     out = paddle.matmul(x, y)
     return paddle.nn.functional.relu(out + b)
 
-def trivial_matrix_binary_gelu_true(x, y, b):
+
+def matmul_add_gelu_true(x, y, b):
     out = paddle.matmul(x, y)
     return paddle.nn.functional.gelu(out + b, True)
+
 
 class CINNSubGraphNet(paddle.nn.Layer):
     def __init__(self, fn):
@@ -42,7 +43,8 @@ class CINNSubGraphNet(paddle.nn.Layer):
         out = self.fn(x, y, b)
         return out
 
-class TestAPMatmulBinaryTriangleShape(unittest.TestCase):
+
+class TestAPMatmulBinary(unittest.TestCase):
     """
     Test Pir API + @to_static + CINN.
     """
@@ -66,8 +68,7 @@ class TestAPMatmulBinaryTriangleShape(unittest.TestCase):
         self.b = paddle.randn(self.b_shape, dtype=self.dtype)
         self.b.stop_gradient = False
 
-    def eval_symbolic(self, use_cinn, profile):
-        net = CINNSubGraphNet(trivial_matrix_binary_gelu_true)
+    def eval_symbolic(self, net, use_cinn, profile):
         input_spec = [
             InputSpec(shape=self.x_shape, dtype=self.dtype),
             InputSpec(shape=self.y_shape, dtype=self.dtype),
@@ -78,12 +79,21 @@ class TestAPMatmulBinaryTriangleShape(unittest.TestCase):
         out = utils.run_with_profile(profile, net, self.x, self.y, self.b)
         return out
 
-    def test_eval_symbolic(self):
+    def test_matmul_add_relu(self):
         profile = False
-        cinn_out = self.eval_symbolic(use_cinn=True, profile=profile)
-        dy_out = self.eval_symbolic(use_cinn=False, profile=profile)
+        net = CINNSubGraphNet(matmul_add_relu)
+        cinn_out = self.eval_symbolic(net, use_cinn=True, profile=profile)
+        dy2st_out = self.eval_symbolic(net, use_cinn=False, profile=profile)
         if not profile:
-            utils.check_result(self.dtype, cinn_out.numpy(), dy_out.numpy())
+            utils.check_result(self.dtype, cinn_out.numpy(), dy2st_out.numpy())
+
+    def test_matmul_add_gelu(self):
+        profile = False
+        net = CINNSubGraphNet(matmul_add_gelu_true)
+        cinn_out = self.eval_symbolic(net, use_cinn=True, profile=profile)
+        dy2st_out = self.eval_symbolic(net, use_cinn=False, profile=profile)
+        if not profile:
+            utils.check_result(self.dtype, cinn_out.numpy(), dy2st_out.numpy())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
AP生成Kernel支持配置自动调优，引入一个`ProfileBestConfig`函数来对Kernel在不同的Config时进行试跑，函数中使用了`cudaEvent_t`来对试跑的Kernel进行计时，接口如下。
```cpp
static int ProfileBestConfig(
    const std::vector<std::function<void(const GemmEpilogueParams &)>>
        &gemm_functions,                                                                                                                                                            
    const GemmEpilogueParams &params)
```

为支持Autotune，需要将生成的Kernel满足封装成`ProfileBestConfig`的统一的接口。修改后生成的Kernel代码如下：
```cpp
#include "cutlass_matmul.cuh"
#include "profile.h"

namespace ap {

template <typename T>
struct VariadicEpilogueFunctor {
  struct Arguments {
    const float* in_ptr_0;
  };

  // Note: need to support vectorized operation
  __forceinline__ __host__ __device__
  T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
    T out;
    float op1_out0 = (args.in_ptr_0[(coord.column)]);
    float op4_out0 = (x + op1_out0);
    float op5_out0 = (0.000000);
    float op6_out0 = (((op4_out0 >= op5_out0) ? (op4_out0) : (op5_out0)));
    out = op6_out0;
    return out;
  }
};

template <int TuningConfigId>
static void RunMatmulWithVariadicKernel(const GemmEpilogueParams &params) {
  using ElementT = float;
  using ElementComputeT = float;

  typename VariadicEpilogueFunctor<ElementComputeT>::Arguments epilogue_args;

  epilogue_args.in_ptr_0 = reinterpret_cast<const float *>(params.epilogue_in_ptrs[0]);

  constexpr int AlignA = AP_ALIGNMENT_float(128);
  constexpr int AlignB = AP_ALIGNMENT_float(32);

  CutlassMatmulAddVariadic<ElementT, ElementComputeT, VariadicEpilogueFunctor,
                           AlignA, AlignB, TuningConfigId>(params,
                                                           epilogue_args);
}

} // namespace ap

extern "C" { 

void MatmulBinaryKernel(void* stream_ptr, const float* input0, const float* input1, float* output, int64_t input0_dim0, int64_t input0_dim1, int64_t input0_dim2, int64_t input1_dim1, const float* in_ptr_0) {
  std::vector<int64_t> input0_shape;
  input0_shape.resize(3);
  input0_shape[0] = input0_dim0;
  input0_shape[1] = input0_dim1;
  input0_shape[2] = input0_dim2;
  
  std::vector<int64_t> input1_shape; 
  input1_shape.resize(2);
  input1_shape[0] = input0_dim2;
  input1_shape[1] = input1_dim1;
    
  cudaStream_t* cuda_stream_ptr = reinterpret_cast<cudaStream_t*>(stream_ptr);
  ap::GemmEpilogueParams params(
      *cuda_stream_ptr, input0, input1, nullptr, output, input0_shape, input1_shape, std::vector<int64_t>{});
  
  std::vector<const void *> epilogue_in_ptrs;
  epilogue_in_ptrs.push_back(in_ptr_0);

  params.SetEpilogues(epilogue_in_ptrs);
  
#if AP_ENABLE_AUTOTUNE
  AP_AUTOTUNE_float(ap::RunMatmulWithVariadicKernel);
#else
  ap::RunMatmulWithVariadicKernel<ap::DefaultConfig::kConfigId>(params);
#endif
}
}
```