### PR TITLE
Optimize the computation of pow.

### DIFF
--- a/tests/ap/matmul/math_function.h
+++ b/tests/ap/matmul/math_function.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+
+namespace ap {
+
+template <typename T>
+__forceinline__ __host__ __device__ T ComputePow(T base, T exponent) {
+  T res = (exponent == static_cast<T>(2))
+              ? (base * base)
+              : ((exponent == static_cast<T>(3)) ? (base * base * base)
+                                                 : (powf(base, exponent)));
+  return res;
+}
+
+} // namespace ap

--- a/tests/ap/op_compute_translator_util.py
+++ b/tests/ap/op_compute_translator_util.py
@@ -260,7 +260,7 @@ class PdOpElementwisePowCodeGen:
     exponent = inputs[1].var_name
     var_name = inputs[0].var_name
     out = self.get_out_cg_val(0)
-    mut_lir_code_gen_ctx.let(out, f"pow({var_name},{exponent})")
+    mut_lir_code_gen_ctx.let(out, f"ComputePow({var_name}, {exponent})")
     return [out]
 
   def get_out_cg_val(self, i):


### PR DESCRIPTION
gelu在`approxiate=True`时，需要计算`x^3`，前端拆解成`elementwise_pow(x, 3)`。CUDA Kernel中`pow`计算比较慢，在特殊情况可优化成一次或多次乘法。

`matmul+add+gelu`Kernel耗时数据如下：
- 优化前
```
Time (%)  Total Time (ns)  Instances  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  --------  --------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
100.0      194,776,106      1,000  194,776.1  194,719.0   193,407   211,967        805.4  void cutlass::Kernel2<cutlass::gemm::kernel::GemmUniversal<cutlass::gemm::threadblock::MmaMultistag…
```

- 优化后
```
Time (%)  Total Time (ns)  Instances  Avg (ns)  Med (ns)  Min (ns)  Max (ns)  StdDev (ns)                                                  Name                                                
 --------  ---------------  ---------  --------  --------  --------  --------  -----------  ----------------------------------------------------------------------------------------------------
100.0       75,987,691      1,000  75,987.7  75,967.0    74,528    78,080        521.4  void cutlass::Kernel2<cutlass::gemm::kernel::GemmUniversal<cutlass::gemm::threadblock::MmaMultistag…
```
