### PR TITLE
Add umprime-relu pass

### DIFF
--- a/tests/ap/make_axpr.sh
+++ b/tests/ap/make_axpr.sh
@@ -14,6 +14,7 @@ FILENAMES_ARRAY=(
     "__main__"
     "topo_drr_pass"
     "op_convertion_drr_pass"
+    "umprime"
     "access_topo_drr"
     "abstract_drr"
     "ap_tpl_codegen"

--- a/tests/ap/test_matmul_binary.py
+++ b/tests/ap/test_matmul_binary.py
@@ -11,6 +11,7 @@ import kernel_arg_id_util
 import low_level_ir_code_gen_ctx_util
 import kernel_arg_translator_util
 import pir
+import umprime
 
 class RemoveDataOpPairPass(access_topo_drr.DrrPass):
   def __init__(self, src_data_op_name, dst_data_op_name):
@@ -189,6 +190,12 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
 
   def constraint(self, o, t):
     program = ir_tools.copy_fused_ops_to_program(o.trivial_op, tensor_match_ctx=t)
+    print("before-umprime: ", program)
+    # umprime passes
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("umprime"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
     print("before-access_topo_pass", program)
     init_pass_manager = ir_tools.create_pass_manager()
     init_down_spider = topo_drr_pass.InitDownSpiderAccessTopoPass("mm_out")
@@ -349,6 +356,11 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
     mut_program = ir_tools.copy_fused_ops_to_program(
       o.trivial_op, tensor_match_ctx=t
     )
+    # umprime passes
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("umprime"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
     self._insert_load_from_global(
       mut_program,
       input_names=["mm_out", "input2"]

--- a/tests/ap/umprime.py
+++ b/tests/ap/umprime.py
@@ -1,0 +1,65 @@
+import access_topo_drr
+import pir
+
+@access_topo_drr.register_drr_pass("pd_op_static_relu", tag="umprime")
+class PdOpReluAccessTopoPass(access_topo_drr.DrrPass):
+  def __init__(self):
+    self.zero = pir.a_f64(DataValue.float64("0"))
+
+  def source_pattern(self, o, t):
+    o.full_op = o.ap_native_op("pd_op.full")
+    o.full_op(
+      [],
+      [t.intermediate]
+    )
+    o.maximum_op = o.ap_native_op("pd_op.maximum")
+    o.maximum_op(
+      [t.input, t.intermediate],
+      [t.output]
+    )
+  def constraint(self, o, t):
+    return o.full_op.value == self.zero
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
+      [t.input],
+      [t.output]
+    )
+
+
+@access_topo_drr.register_drr_pass("pd_op_dynamic_relu", tag="umprime")
+class PdOpReluAccessTopoPass(access_topo_drr.DrrPass):
+  def __init__(self):
+    self.zero = pir.a_f64(DataValue.float64("0"))
+
+  def source_pattern(self, o, t):
+    o.full_op = o.ap_native_op("pd_op.full")
+    o.full_op(
+      [],
+      [t.intermediate0]
+    )
+    o.generate_shape_op = o.ap_native_op("cinn_op.generate_shape")
+    o.generate_shape_op(
+      [t.input0],
+      [t.intermediate1]
+    )
+    o.expand_op = o.ap_native_op("pd_op.expand")
+    o.expand_op(
+      [t.intermediate0, t.intermediate1],
+      [t.intermediate2]
+    )
+    o.maximum_op = o.ap_native_op("pd_op.maximum")
+    o.maximum_op(
+      [t.input1, t.intermediate2],
+      [t.output]
+    )
+  def constraint(self, o, t):
+    return o.full_op.value == self.zero
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
+      [t.input1],
+      [t.output]
+    )


### PR DESCRIPTION
增加umprime 模块。
该模块负责在拓扑化简和计算图翻译阶段的开始进行算子组合，来解决组合算子拆解引起的算子过多等问题。

本次增加了对relu算子在动静态两种模式下的算子组合pass。