### PR TITLE
support multiple in/out

### DIFF
--- a/tests/ap/__main__.py
+++ b/tests/ap/__main__.py
@@ -1,3 +1,4 @@
 # import test_trivial_reduce
 # import test_binary_trivial_reduce
 import test_matmul_binary
+import test_matmul_epilogue

--- a/tests/ap/low_level_ir_code_gen_ctx_util.py
+++ b/tests/ap/low_level_ir_code_gen_ctx_util.py
@@ -23,5 +23,10 @@ class CudaLikeIrCodeGenCtx:
         type_cast_str = "" if is_same else f"static_cast<{self.compute_dtype_name}>"
         self.stmts.append(f"{type_name} {var.var_name} = {type_cast_str}({val_name});")
 
+    def store(self, dtype, dst, offset_var_name, src):
+        is_same = dtype == self.dtype2type_name[self.compute_dtype]
+        type_cast_str = "" if is_same else f"static_cast<{dtype}>"
+        self.stmts.append(f"{dst}[{offset_var_name}] = {type_cast_str}({src});")
+
     def get_stmts_joined_str(self, indent):
         return f"\n{indent}".join([*self.stmts])

--- a/tests/ap/make_axpr.sh
+++ b/tests/ap/make_axpr.sh
@@ -19,6 +19,7 @@ FILENAMES_ARRAY=(
     "ap_tpl_codegen"
     "matmul_binary_tpl"
     "test_matmul_binary"
+    "test_matmul_epilogue"
 )
 for filename in "${FILENAMES_ARRAY[@]}"
 do

--- a/tests/ap/matmul/matmul.h
+++ b/tests/ap/matmul/matmul.h
@@ -89,7 +89,9 @@ struct GemmEpilogueParams {
   std::vector<int64_t> input0_shape;
   std::vector<int64_t> input1_shape;
   std::vector<const void *> epilogue_in_ptrs;
+  std::vector<void *> epilogue_out_ptrs;
   std::vector<std::vector<int64_t>> epilogue_in_shapes;
+  std::vector<std::vector<int64_t>> epilogue_out_shapes;
 
   GemmEpilogueParams() {}
   GemmEpilogueParams(cudaStream_t stream, const void *input, const void *weight,
@@ -156,16 +158,23 @@ struct GemmEpilogueParams {
     shape_args.ldc_bias = (!bias || is_C_bias) ? 0 : n;
   }
 
-  void SetEpilogues(const std::vector<const void *> &in_ptrs) {
+  void SetEpilogues(const std::vector<const void *> &in_ptrs, 
+                    const std::vector< void *> &out_ptrs) {
     epilogue_in_ptrs = in_ptrs;
+    epilogue_out_ptrs = out_ptrs;
   }
 
   void
   SetEpilogueAndShapes(const std::vector<const void *> &in_ptrs,
-                       const std::vector<std::vector<int64_t>> &in_shapes) {
+                       const std::vector<std::vector<int64_t>> &in_shapes,
+                       const std::vector<void *> &out_ptrs,
+                       const std::vector<std::vector<int64_t>> &out_shapes) {
     ASSERT_CHECK(in_ptrs.size() == in_shapes.size());
     epilogue_in_ptrs = in_ptrs;
     epilogue_in_shapes = in_shapes;
+    ASSERT_CHECK(out_ptrs.size() == out_shapes.size());
+    epilogue_out_ptrs = out_ptrs;
+    epilogue_out_shapes = out_shapes;
   }
 };
 

--- a/tests/ap/matmul/tests/matmul_binary_kernel.cu
+++ b/tests/ap/matmul/tests/matmul_binary_kernel.cu
@@ -47,13 +47,15 @@ void MatmulAddBinaryKernel(
     cudaStream_t *stream, const void *input, const void *weight,
     const void *bias, void *output,
     const std::vector<const void *> &epilogue_ins,
+    const std::vector<void *> &epilogue_outs,
     const std::vector<int64_t> &input_shape,
     const std::vector<int64_t> &weight_shape,
     const std::vector<int64_t> &bias_shape,
-    const std::vector<std::vector<int64_t>> &epilogue_shapes) {
+    const std::vector<std::vector<int64_t>> &epilogue_in_shapes,
+    const std::vector<std::vector<int64_t>> &epilogue_out_shapes) {
   GemmEpilogueParams params(*stream, input, weight, bias, output, input_shape,
                             weight_shape, bias_shape);
-  params.SetEpilogueAndShapes(epilogue_ins, epilogue_shapes);
+  params.SetEpilogueAndShapes(epilogue_ins, epilogue_in_shapes, epilogue_outs, epilogue_out_shapes);
 
 #if AP_ENABLE_AUTOTUNE
 #if AP_USE_FLOAT16

--- a/tests/ap/matmul_binary_tpl.py
+++ b/tests/ap/matmul_binary_tpl.py
@@ -97,6 +97,11 @@ class MatmulBinaryTemplate:
             lambda pair: pair[0].runtime_getter, all_kernel_arg_id_and_unique_names
         )
 
+    def init_outputs(self):
+        out_tensor_data_nums = self.mut_kernel_arg_id_registry.out_tensor_data_ptr_seq_no + 1
+        stmt = map(lambda i: f"out{i}", range(out_tensor_data_nums))
+        return "T " + f", ".join(stmt) + ";"
+
     def get_kernel_arg_types(self):
         all_kernel_arg_id_and_unique_names = (
             self.mut_kernel_arg_id_registry.all_kernel_arg_id2unique_name.items()
@@ -208,9 +213,9 @@ struct VariadicEpilogueFunctor {
   // Note: need to support vectorized operation
   __forceinline__ __host__ __device__
   T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
-    T out;
+    ${AP_OUTPUTS_INIT}
     ${AP_EPILOGUE_COMPUTATION_STATEMENTS}
-    return out;
+    return out0;
   }
 };
 
@@ -260,6 +265,7 @@ void ${kernel_name}(void* stream_ptr, ${AP_KERNEL_ARGS_DECLARE}) {
             code_template.replace(
                 "${AP_EPILOGUE_COMPUTATION_STATEMENTS}", trivial_code_str
             )
+            .replace("${AP_OUTPUTS_INIT}", self.init_outputs())
             .replace(
                 "${AP_KERNEL_ARGS_DECLARE}",
                 self.get_kernel_arg_list_str(for_declare=True),

--- a/tests/ap/op_compute_translator_util.py
+++ b/tests/ap/op_compute_translator_util.py
@@ -83,6 +83,56 @@ class ApOpStoreToRegisterCodeGen:
     return register_var_name_attr.match(a_str=lambda x:x)
 
 
+class ApOpStoreToGlobalCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+    self.ptr_type2data_type = OrderedDict(
+        [
+            [PointerType.const_float_ptr, "const float"],
+            [PointerType.const_float16_ptr, "const half"],
+            [PointerType.float_ptr, "float"],
+            [PointerType.float16_ptr, "half"],
+        ]
+    )
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    index_func_unique_id_attr = self.op_property.attributes.index_func_unique_id
+    index_func_unique_id = index_func_unique_id_attr.match(a_str=lambda x:x)
+    offset_var_name = self.index_program_translator_map.get_offset_var_name(
+      index_func_unique_id=index_func_unique_id,
+      mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
+      mut_lir_code_gen_ctx=mut_lir_code_gen_ctx,
+    )
+    glb_data_type = self.get_glb_type(mut_kernel_arg_id_registry, index_func_unique_id)
+    ptr_var_name = self.kernel_arg_translator.get_use_name(arg_name)
+    mut_lir_code_gen_ctx.store(glb_data_type, ptr_var_name, offset_var_name, inputs[1].var_name)
+    return []
+
+  def get_glb_type(self, mut_kernel_arg_id_registry, index_func_unique_id):
+    arg_name = mut_kernel_arg_id_registry.get_out_tensor_data_ptr_var_name(index_func_unique_id)
+    kernel_arg_name2ids = OrderedDict(
+      map(
+        lambda item: [item[1], item[0]],
+        mut_kernel_arg_id_registry.generated_kernel_arg_id2unique_name.items()
+      )
+    )
+    kernel_arg_id = kernel_arg_name2ids[arg_name]
+    return self.ptr_type2data_type[kernel_arg_id.type]
+
+  def get_out_var_name(self):
+    register_var_name_attr = self.op_property.attributes.register_var_name
+    return register_var_name_attr.match(a_str=lambda x:x)
+
+
 class PdOpDataCodeGen:
   def __init__(self,
                op_property,

--- a/tests/ap/paddle-tests/test_matmul_epilogue.py
+++ b/tests/ap/paddle-tests/test_matmul_epilogue.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from os.path import dirname
+
+sys.path.append(dirname(__file__))
+
+import unittest
+import utils
+import paddle
+from paddle.static import InputSpec
+
+
+def trivial_matrix_binary(x, y, b):
+    out = paddle.matmul(x, y)
+    bias = out - b
+    relu = paddle.nn.functional.relu(out)
+    exp = paddle.exp(relu)
+    return bias, relu, exp
+
+class CINNSubGraphNet(paddle.nn.Layer):
+    def __init__(self, fn):
+        super().__init__()
+        self.fn = fn
+
+    def forward(self, x, y, b):
+        out = self.fn(x, y, b)
+        return out
+
+class TestAPMatmulBinaryTriangleShape(unittest.TestCase):
+    """
+    Test Pir API + @to_static + CINN.
+    """
+
+    def setUp(self):
+        paddle.seed(2022)
+        self.prepare_data()
+
+    def prepare_data(self):
+        self.dtype = "float16"
+
+        self.x_shape = [4, 65536, 128]
+        self.x = paddle.randn(self.x_shape, dtype=self.dtype)
+        self.x.stop_gradient = False
+
+        self.y_shape = [128, 32]
+        self.y = paddle.randn(self.y_shape, dtype=self.dtype)
+        self.y.stop_gradient = False
+
+        # self.b_shape = [4, 65536, 32]
+        self.b_shape = [32]
+        self.b = paddle.randn(self.b_shape, dtype=self.dtype)
+        self.b.stop_gradient = False
+
+    def eval_symbolic(self, use_cinn, profile):
+        net = CINNSubGraphNet(trivial_matrix_binary)
+        input_spec = [
+            InputSpec(shape=self.x_shape, dtype=self.dtype),
+            InputSpec(shape=self.y_shape, dtype=self.dtype),
+            InputSpec(shape=self.b_shape, dtype=self.dtype),
+        ]
+        net = utils.apply_to_static(net, use_cinn, input_spec)
+        net.eval()
+        out = utils.run_with_profile(profile, net, self.x, self.y, self.b)
+        return out
+
+    def test_eval_symbolic(self):
+        profile = False
+        cinn_out = self.eval_symbolic(use_cinn=True, profile=profile)
+        dy_out = self.eval_symbolic(use_cinn=False, profile=profile)
+        if not profile:
+            for i,(a,b) in enumerate(zip(cinn_out,dy_out)):
+                utils.check_result(self.dtype, a.numpy(), b.numpy())
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ap/test_matmul_epilogue.py
+++ b/tests/ap/test_matmul_epilogue.py
@@ -1,0 +1,540 @@
+import abstract_drr
+import access_topo_drr
+import topo_drr_pass
+import umprime
+import matmul_epilogue_pass
+import op_convertion_drr_pass
+import matmul_binary_tpl
+import ir_tools
+import index_program_translator_util
+import op_compute_translator_util
+import program_translator_util
+import kernel_arg_id_util
+import low_level_ir_code_gen_ctx_util
+import kernel_arg_translator_util
+import pir
+
+
+class MatmulEpilogueFusion(abstract_drr.DrrPass):
+  def source_pattern(self, o, t):
+    in_num = self.number_of_inputs()
+    out_num = self.number_of_outputs()
+    o.matmul_op = o.ap_native_op("pd_op.matmul")
+    o.matmul_op(
+        [t.input0, t.input1],
+        [t.mm_out]
+    )
+    o.trivial_op = o.ap_trivial_fusion_op()
+    o.trivial_op(
+      [t.mm_out, *map(lambda index: getattr(t, f"input{index+2}"),  range(in_num - 2))],
+      map(lambda index: getattr(t, f"output{index}"),  range(out_num)),
+    )
+
+
+  def result_pattern(self, o, t):
+    in_num = self.number_of_inputs()
+    out_num = self.number_of_outputs()
+    o.fustion_op = o.ap_pattern_fusion_op(self.code_gen)
+    o.fustion_op(
+      map(lambda index: getattr(t, f"input{index}"),  range(in_num)),
+      map(lambda index: getattr(t, f"output{index}"),  range(out_num))
+    )
+
+  def constraint(self, o, t):
+    program = ir_tools.copy_fused_ops_to_program(o.trivial_op, tensor_match_ctx=t)
+    print("before-umprime: ", program)
+    # umprime passes
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("umprime"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("before-access_topo_pass", program)
+    init_pass_manager = ir_tools.create_pass_manager()
+    init_down_spider = topo_drr_pass.InitDownSpiderAccessTopoPass("mm_out")
+    init_pass_manager.add_pass(
+        ir_tools.create_access_topo_drr_one_step_pass(init_down_spider)
+    )
+    outputs_name_list = map(lambda i: f"output{i}", range(self.number_of_outputs()))
+    inputs_name_list = map(lambda i: f"input{i+2}", range(self.number_of_inputs() - 2)) if self.number_of_inputs() > 2 else []
+    print('inputs_name_list: ', ', '.join(inputs_name_list))
+    init_fake_data_for_yield_input = topo_drr_pass.FakeDataForYieldAccessTopoPass(
+      outputs_name_list
+    )
+    init_pass_manager.add_pass(
+        ir_tools.create_access_topo_drr_one_step_pass(init_fake_data_for_yield_input)
+    )
+    init_pass_manager.run(program)
+    print("after-init-access_topo_pass", program)
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("default"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("after-apply-access_topo_pass", program)
+    pass_manager = ir_tools.create_pass_manager()
+    map(lambda dst_name: pass_manager.add_pass(
+      ir_tools.create_access_topo_drr_one_step_pass(
+          matmul_epilogue_remove_pass.RemoveDataOpPairPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
+          inputs_name_list
+    )
+    map(lambda dst_name: pass_manager.add_pass(
+      ir_tools.create_access_topo_drr_one_step_pass(
+          matmul_epilogue_remove_pass.RemoveDataOp2SumOp2DataOpPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
+          inputs_name_list
+    )
+
+    map(lambda dst_name: pass_manager.add_pass(
+      ir_tools.create_access_topo_drr_one_step_pass(
+          matmul_epilogue_remove_pass.RemoveDataOpPairPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
+          outputs_name_list
+    )
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(program)
+    print("after-remove-input-output-access_topo_pass", program)
+    return program.empty()
+
+  def _insert_load_from_global(self, program, input_names):
+    init_pass_manager = ir_tools.create_pass_manager()
+    def AddPass(input_name):
+        ir_pass = topo_drr_pass.InitNaiveLoadFromGlobalAccessTopoPass(input_name)
+        init_pass_manager.add_pass(
+            ir_tools.create_access_topo_drr_one_step_pass(ir_pass)
+        )
+    map(AddPass, input_names)
+    init_pass_manager.run(program)
+
+  def _insert_store_to_global(self, program, output_names):
+    init_pass_manager = ir_tools.create_pass_manager()
+    ir_pass = topo_drr_pass.FakeDataStoreToGlobalForYieldAccessTopoPass(output_names)
+    init_pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(ir_pass))
+    init_pass_manager.run(program)
+
+  def _make_kernel_arg_translator(self):
+    return matmul_binary_tpl.make_kernel_arg_translator()
+
+  def _apply_topo_access_passes(self, mut_program, anchor_data_op_name):
+    init_pass_manager = ir_tools.create_pass_manager()
+    init_down_spider = topo_drr_pass.InitDownSpiderAccessTopoPass(anchor_data_op_name)
+    init_pass_manager.add_pass(
+        ir_tools.create_access_topo_drr_one_step_pass(init_down_spider)
+    )
+    init_pass_manager.run(mut_program)
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("default"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+
+  def _simplify_index_program(self, mut_program):
+    pass_manager = ir_tools.create_pass_manager()
+    drr_pass = topo_drr_pass.ConvertUpSpiderStoreDataOpToYieldOpPass()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    drr_pass = topo_drr_pass.ConvertDownSpiderStoreDataOpToYieldOpPass()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    return mut_program
+
+  def _make_index_func_unique_id2index_program(
+          self, compute_program, anchor_data_op_name, input_names, output_names):
+    full_index_program = compute_program.clone()
+    self._apply_topo_access_passes(full_index_program, anchor_data_op_name)
+    print('full_index_program: ', full_index_program)
+    def MatchAndCopyInputIndex(dst_input_name):
+        pass_manager = ir_tools.create_pass_manager()
+        removed_programs = MutableList()
+        rm_elementwise_drr_pass = matmul_epilogue_remove_pass.RemoveElementInputIndexPass(
+            src_data_op_name=anchor_data_op_name,
+            dst_load_from_global_op_name=dst_input_name
+        )
+        rm_elementwise_ir_pass = ir_tools.create_access_topo_drr_one_step_pass(
+            rm_elementwise_drr_pass,
+            matched_pattern_mut_list=removed_programs
+        )
+        pass_manager.add_pass(rm_elementwise_ir_pass)
+        rm_broadcast_drr_pass = matmul_epilogue_remove_pass.RemoveBroadcastInputIndexPass(
+            src_data_op_name=anchor_data_op_name,
+            dst_load_from_global_op_name=dst_input_name
+        )
+        rm_broadcast_ir_pass = ir_tools.create_access_topo_drr_one_step_pass(
+            rm_broadcast_drr_pass,
+            matched_pattern_mut_list=removed_programs
+        )
+        pass_manager.add_pass(rm_broadcast_ir_pass)
+        pass_manager.run(full_index_program)
+        def Converter(program):
+          return [dst_input_name, self._simplify_index_program(program)]
+        return map(Converter, removed_programs)
+    input_and_index_programs = flat_map(MatchAndCopyInputIndex, input_names)
+    def MatchAndCopyOutputIndex(dst_output_name):
+        print('full_index_program output: ', full_index_program)
+        pass_manager = ir_tools.create_pass_manager()
+        removed_programs = MutableList()
+        drr_pass = matmul_epilogue_remove_pass.RemoveOutputIndexPass(
+            src_data_op_name=anchor_data_op_name,
+            dst_store_to_global_op_name=dst_output_name
+        )
+        ir_pass = ir_tools.create_access_topo_drr_one_step_pass(
+            drr_pass,
+            matched_pattern_mut_list=removed_programs
+        )
+        pass_manager.add_pass(ir_pass)
+        pass_manager.run(full_index_program)
+
+        def Converter(program):
+          return [dst_output_name, self._simplify_index_program(program)]
+        print('len removed of output: ', len(removed_programs))
+        return map(Converter, removed_programs)
+    output_and_index_programs = flat_map(MatchAndCopyOutputIndex, output_names)
+    return OrderedDict([*input_and_index_programs, *output_and_index_programs])
+
+  def _replace_with_load_from_register(
+      self, mut_program, load_ir_value_name, register_var_name):
+    pass_manager = ir_tools.create_pass_manager()
+    drr_pass = topo_drr_pass.ReplaceWithLoadFromRegisterPass(
+        name=load_ir_value_name,
+        register_var_name=register_var_name
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    return mut_program
+
+  def _replace_with_store_to_register(
+      self, mut_program, store_ir_value_name, register_var_name):
+    pass_manager = ir_tools.create_pass_manager()
+    drr_pass = topo_drr_pass.ReplaceWithStoreToRegisterPass(
+        name=store_ir_value_name,
+        register_var_name=register_var_name
+    )
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    return mut_program
+
+  def _get_program_translator(self, ctx, o, t):
+    outputs_name_list = map(lambda i: f"output{i}", range(self.number_of_outputs()))
+    other_outputs_name_list = map(lambda i: f"output{i+1}", range(self.number_of_outputs()-1))
+    local_outputs_name_list = map(lambda i: f"out{i}", range(self.number_of_outputs()))
+    inputs_name_list = map(lambda i: f"input{i+2}", range(self.number_of_inputs() - 2)) if self.number_of_inputs() > 2 else []
+    mut_program = ir_tools.copy_fused_ops_to_program(
+      o.trivial_op, tensor_match_ctx=t
+    )
+    print("before-umprime: ", mut_program)
+    # umprime passes
+    pass_manager = ir_tools.create_pass_manager()
+    pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("umprime"))
+    pass_manager.add_pass(ir_tools.create_dce_pass())
+    pass_manager.run(mut_program)
+    self._insert_load_from_global(
+      mut_program,
+      input_names=["mm_out"]
+    )
+    self._insert_load_from_global(
+      mut_program,
+      input_names=inputs_name_list
+    )
+    self._insert_store_to_global(
+      mut_program,
+      output_names=outputs_name_list
+    )
+    kernel_arg_translator = self._make_kernel_arg_translator()
+    index_func_unique_id2index_program = self._make_index_func_unique_id2index_program(
+      mut_program,
+      anchor_data_op_name="mm_out",
+      input_names=inputs_name_list,
+      output_names=other_outputs_name_list,
+    )
+    print("index_func_unique_id2index_program:\n", index_func_unique_id2index_program)
+    index_program_translator_map = index_program_translator_util.IndexProgramTranslatorMap(
+      index_func_unique_id2index_program=index_func_unique_id2index_program,
+      kernel_arg_translator=kernel_arg_translator,
+      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names()
+    )
+    self._replace_with_load_from_register(
+      mut_program,
+      load_ir_value_name="mm_out",
+      register_var_name="x"
+    )
+    self._replace_with_store_to_register(mut_program, "output0", "out0")
+    print("mut_program:", mut_program)
+    op_compute_translator_maker = op_compute_translator_util.OpComputeTranslatorFactory()
+    print('berfore translator')
+    program_translator = program_translator_util.ProgramTranslator(
+      program_property=mut_program.copy_to_const_program_data(),
+      kernel_arg_translator=kernel_arg_translator,
+      index_program_translator_map=index_program_translator_map,
+      op_translator_maker=op_compute_translator_maker
+    )
+    print('after translator')
+
+    return program_translator
+
+  def code_gen(self, ctx, o, t):
+    program_translator = self._get_program_translator(ctx, o, t)
+    mut_kernel_arg_id_registry = kernel_arg_id_util.KernelArgIdNameRegistry(
+      code_gen_ctx=ctx,
+      tensor_match_ctx=t,
+      name_prefix=""
+    )
+    print('after registry')
+
+    template_module = matmul_binary_tpl.MatmulBinaryTemplate(
+      program_translator=program_translator,
+      mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
+    )
+    print('after module')
+
+    def get_symbolic_shape_args_list(sym_dim):
+        return ctx.dim_expr_kernel_arg_id(sym_dim)
+    input0_shape_kargs = map(get_symbolic_shape_args_list, t.input0.symbolic_shape_to_list())
+    input1_shape_kargs = map(get_symbolic_shape_args_list, t.input1.symbolic_shape_to_list())
+    print('before compile')
+    return template_module.compile(
+        input0_karg=ctx.in_tensor_data_ptr_kernel_arg_id(t.input0),
+        input1_karg=ctx.in_tensor_data_ptr_kernel_arg_id(t.input1),
+        output_karg=ctx.out_tensor_data_ptr_kernel_arg_id(t.output0),
+        input0_shape_kargs=input0_shape_kargs,
+        input1_shape_kargs=input1_shape_kargs,
+    )
+
+class NumberOfInputsTrait0():
+  def number_of_inputs(self):
+    return 0
+
+class NumberOfInputsTrait1():
+  def number_of_inputs(self):
+    return 1
+
+class NumberOfInputsTrait2():
+  def number_of_inputs(self):
+    return 2
+
+class NumberOfInputsTrait3():
+  def number_of_inputs(self):
+    return 3
+
+class NumberOfInputsTrait4():
+  def number_of_inputs(self):
+    return 4
+
+class NumberOfInputsTrait5():
+  def number_of_inputs(self):
+    return 5
+
+class NumberOfInputsTrait6():
+  def number_of_inputs(self):
+    return 6
+
+class NumberOfInputsTrait7():
+  def number_of_inputs(self):
+    return 7
+
+class NumberOfInputsTrait8():
+  def number_of_inputs(self):
+    return 8
+
+class NumberOfInputsTrait9():
+  def number_of_inputs(self):
+    return 9
+
+class NumberOfInputsTrait10():
+  def number_of_inputs(self):
+    return 10
+
+class NumberOfInputsTrait11():
+  def number_of_inputs(self):
+    return 11
+
+class NumberOfInputsTrait12():
+  def number_of_inputs(self):
+    return 12
+
+class NumberOfInputsTrait13():
+  def number_of_inputs(self):
+    return 13
+
+class NumberOfInputsTrait14():
+  def number_of_inputs(self):
+    return 14
+
+class NumberOfInputsTrait15():
+  def number_of_inputs(self):
+    return 15
+
+class NumberOfInputsTrait16():
+  def number_of_inputs(self):
+    return 16
+
+class NumberOfInputsTrait17():
+  def number_of_inputs(self):
+    return 17
+
+
+class NumberOfOutputsTrait0():
+  def number_of_outputs(self):
+    return 0
+
+class NumberOfOutputsTrait1():
+  def number_of_outputs(self):
+    return 1
+
+class NumberOfOutputsTrait2():
+  def number_of_outputs(self):
+    return 2
+
+class NumberOfOutputsTrait3():
+  def number_of_outputs(self):
+    return 3
+
+class NumberOfOutputsTrait4():
+  def number_of_outputs(self):
+    return 4
+
+class NumberOfOutputsTrait5():
+  def number_of_outputs(self):
+    return 5
+
+class NumberOfOutputsTrait6():
+  def number_of_outputs(self):
+    return 6
+
+class NumberOfOutputsTrait7():
+  def number_of_outputs(self):
+    return 7
+
+class NumberOfOutputsTrait8():
+  def number_of_outputs(self):
+    return 8
+
+class NumberOfOutputsTrait9():
+  def number_of_outputs(self):
+    return 9
+
+class NumberOfOutputsTrait10():
+  def number_of_outputs(self):
+    return 10
+
+class NumberOfOutputsTrait11():
+  def number_of_outputs(self):
+    return 11
+
+class NumberOfOutputsTrait12():
+  def number_of_outputs(self):
+    return 12
+
+class NumberOfOutputsTrait13():
+  def number_of_outputs(self):
+    return 13
+
+class NumberOfOutputsTrait14():
+  def number_of_outputs(self):
+    return 14
+
+class NumberOfOutputsTrait15():
+  def number_of_outputs(self):
+    return 15
+
+class NumberOfOutputsTrait16():
+  def number_of_outputs(self):
+    return 16
+
+class NumberOfOutputsTrait17():
+  def number_of_outputs(self):
+    return 17
+
+class NumberOfOutputsTrait18():
+  def number_of_outputs(self):
+    return 18
+
+class NumberOfOutputsTrait19():
+  def number_of_outputs(self):
+    return 19
+
+class NumberOfOutputsTrait20():
+  def number_of_outputs(self):
+    return 20
+
+class NumberOfOutputsTrait21():
+  def number_of_outputs(self):
+    return 21
+
+class NumberOfOutputsTrait22():
+  def number_of_outputs(self):
+    return 22
+def get_mixin_class(base_class, number_of_inputs, number_of_outputs):
+  num_inputs_to_input_trait_class = [
+    None,
+    NumberOfInputsTrait1,
+    NumberOfInputsTrait2,
+    NumberOfInputsTrait3,
+    NumberOfInputsTrait3,
+    NumberOfInputsTrait4,
+    NumberOfInputsTrait5,
+    NumberOfInputsTrait6,
+    NumberOfInputsTrait7,
+    NumberOfInputsTrait8,
+    NumberOfInputsTrait9,
+    NumberOfInputsTrait10,
+    NumberOfInputsTrait11,
+    NumberOfInputsTrait12,
+    NumberOfInputsTrait13,
+    NumberOfInputsTrait14,
+    NumberOfInputsTrait15,
+    NumberOfInputsTrait16,
+    NumberOfInputsTrait17,
+  ]
+  num_outputs_to_output_trait_class = [
+    None,
+    NumberOfOutputsTrait1,
+    NumberOfOutputsTrait2,
+    NumberOfOutputsTrait3,
+    NumberOfOutputsTrait4,
+    NumberOfOutputsTrait5,
+    NumberOfOutputsTrait6,
+    NumberOfOutputsTrait7,
+    NumberOfOutputsTrait8,
+    NumberOfOutputsTrait9,
+    NumberOfOutputsTrait10,
+    NumberOfOutputsTrait11,
+    NumberOfOutputsTrait12,
+    NumberOfOutputsTrait13,
+    NumberOfOutputsTrait14,
+    NumberOfOutputsTrait15,
+    NumberOfOutputsTrait16,
+    NumberOfOutputsTrait17,
+    NumberOfOutputsTrait18,
+    NumberOfOutputsTrait19,
+    NumberOfOutputsTrait20,
+    NumberOfOutputsTrait21,
+    NumberOfOutputsTrait22,
+  ]
+  return type(
+    f"MatmulEpilogueFusion{number_of_inputs}_{number_of_outputs}",
+    [
+      base_class,
+      num_inputs_to_input_trait_class[number_of_inputs],
+      num_outputs_to_output_trait_class[number_of_outputs],
+    ],
+    BuiltinSerializableAttrMap()
+  )
+
+# abstract_drr.register_drr_pass("matmul_binary_outs_fusion", nice=0)(get_mixin_class(MatmulEpilogueFusion, 3, 2))
+
+def register_class(base_class, max_num_inputs, max_num_outputs):
+  def register_drr_class(num_inputs, num_outputs):
+    abstract_drr.register_drr_pass(f"matmul_binary_in{num_inputs}_out{num_outputs}_fusion", nice=0)(
+      get_mixin_class(base_class, num_inputs, num_outputs)
+    )
+
+  def register_num_inputs_drr_classes(num_inputs):
+
+    def register_num_outputs_drr_classes(num_outputs):
+      return register_drr_class(num_inputs+2, num_outputs+1)
+
+    map(register_num_outputs_drr_classes, range(max_num_outputs))
+    print('done max outputs')
+    return None
+
+  map(register_num_inputs_drr_classes, range(max_num_inputs))
+  return None
+
+register_class(base_class=MatmulEpilogueFusion, max_num_inputs=10, max_num_outputs=10)

--- a/tests/ap/test_matmul_epilogue.py
+++ b/tests/ap/test_matmul_epilogue.py
@@ -73,18 +73,18 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
     pass_manager = ir_tools.create_pass_manager()
     map(lambda dst_name: pass_manager.add_pass(
       ir_tools.create_access_topo_drr_one_step_pass(
-          matmul_epilogue_remove_pass.RemoveDataOpPairPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
+          matmul_epilogue_pass.RemoveDataOpPairPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
           inputs_name_list
     )
     map(lambda dst_name: pass_manager.add_pass(
       ir_tools.create_access_topo_drr_one_step_pass(
-          matmul_epilogue_remove_pass.RemoveDataOp2SumOp2DataOpPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
+          matmul_epilogue_pass.RemoveDataOp2SumOp2DataOpPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
           inputs_name_list
     )
 
     map(lambda dst_name: pass_manager.add_pass(
       ir_tools.create_access_topo_drr_one_step_pass(
-          matmul_epilogue_remove_pass.RemoveDataOpPairPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
+          matmul_epilogue_pass.RemoveDataOpPairPass(src_data_op_name="mm_out", dst_data_op_name=dst_name))), 
           outputs_name_list
     )
     pass_manager.add_pass(ir_tools.create_dce_pass())
@@ -141,7 +141,7 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
     def MatchAndCopyInputIndex(dst_input_name):
         pass_manager = ir_tools.create_pass_manager()
         removed_programs = MutableList()
-        rm_elementwise_drr_pass = matmul_epilogue_remove_pass.RemoveElementInputIndexPass(
+        rm_elementwise_drr_pass = matmul_epilogue_pass.RemoveElementInputIndexPass(
             src_data_op_name=anchor_data_op_name,
             dst_load_from_global_op_name=dst_input_name
         )
@@ -150,7 +150,7 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
             matched_pattern_mut_list=removed_programs
         )
         pass_manager.add_pass(rm_elementwise_ir_pass)
-        rm_broadcast_drr_pass = matmul_epilogue_remove_pass.RemoveBroadcastInputIndexPass(
+        rm_broadcast_drr_pass = matmul_epilogue_pass.RemoveBroadcastInputIndexPass(
             src_data_op_name=anchor_data_op_name,
             dst_load_from_global_op_name=dst_input_name
         )
@@ -168,7 +168,7 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
         print('full_index_program output: ', full_index_program)
         pass_manager = ir_tools.create_pass_manager()
         removed_programs = MutableList()
-        drr_pass = matmul_epilogue_remove_pass.RemoveOutputIndexPass(
+        drr_pass = matmul_epilogue_pass.RemoveOutputIndexPass(
             src_data_op_name=anchor_data_op_name,
             dst_store_to_global_op_name=dst_output_name
         )

--- a/tests/ap/test_matmul_epilogue.sh
+++ b/tests/ap/test_matmul_epilogue.sh
@@ -1,0 +1,6 @@
+export CUDA_VISIBLE_DEVICES="2"
+export NVIDIA_TF32_OVERRIDE=0
+
+sh make_axpr.sh test_matmul_epilogue
+# export GLOG_vmodule=ap_generic_drr_pass=6
+FLAGS_enable_ap=1 AP_WORKSPACE_DIR=$(pwd)/ap_workspace AP_PATH=$(pwd)/ FLAGS_check_infer_symbolic=1 FLAGS_enable_pir_api=1 FLAGS_cinn_bucket_compile=True FLAGS_prim_enable_dynamic=true FLAGS_prim_all=True FLAGS_pir_apply_shape_optimization_pass=1 FLAGS_group_schedule_tiling_first=1 FLAGS_cinn_new_group_scheduler=1 python $(pwd)/paddle-tests/test_matmul_epilogue.py


### PR DESCRIPTION
支持了多输入输出，生成如下cuda代码：

```c++
// auto generated codes
#include <cuda.h>
#include <cuda_fp16.h>
#include <vector>

#include "cutlass_matmul.cuh"
#include "profile.h"

namespace ap {

template <typename T>
struct VariadicEpilogueFunctor {
  struct Arguments {
    const half* in_ptr_0;
    int64_t input0_dim1;
    int64_t input1_dim1;
    half* out_ptr_0;
    half* out_ptr_1;
  };

  // Note: need to support vectorized operation
  __forceinline__ __host__ __device__
  T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
    T out0, out1, out2;
    float op1_out0 = static_cast<float>(args.in_ptr_0[(coord.column)]);
    float op3_out0 = static_cast<float>((x > 0 ? x : 0) );
    float op5_out0 = static_cast<float>((x - op1_out0));
    out0 = op5_out0;
    float op7_out0 = static_cast<float>(expf(op3_out0));
    args.out_ptr_0[(coord.batch * args.input0_dim1 * args.input1_dim1 + coord.row * args.input1_dim1 + coord.column)] = static_cast<half>(op7_out0);
    args.out_ptr_1[(coord.batch * args.input0_dim1 * args.input1_dim1 + coord.row * args.input1_dim1 + coord.column)] = static_cast<half>(op3_out0);
    return out0;
  }
};

template <int TuningConfigId>
static void RunMatmulWithVariadicKernel(const GemmEpilogueParams &params, const half* input0, const half* input1, half* output, int64_t input0_dim0, int64_t input0_dim1, int64_t input0_dim2, int64_t input1_dim1, const half* in_ptr_0, half* out_ptr_0, half* out_ptr_1) {
  using ElementT = half;
  using ElementComputeT = float;

  typename VariadicEpilogueFunctor<ElementComputeT>::Arguments epilogue_args;

  epilogue_args.in_ptr_0 = in_ptr_0;
  epilogue_args.input0_dim1 = input0_dim1;
  epilogue_args.input1_dim1 = input1_dim1;
  epilogue_args.out_ptr_0 = out_ptr_0;
  epilogue_args.out_ptr_1 = out_ptr_1;

  constexpr int AlignA = AP_ALIGNMENT_half(128);
  constexpr int AlignB = AP_ALIGNMENT_half(32);

  CutlassMatmulAddVariadic<ElementT, ElementComputeT, VariadicEpilogueFunctor,
                           AlignA, AlignB, TuningConfigId>(params,
                                                           epilogue_args);
}

extern "C" {

void MatmulBinaryKernel(void* stream_ptr, const half* input0, const half* input1, half* output, int64_t input0_dim0, int64_t input0_dim1, int64_t input0_dim2, int64_t input1_dim1, const half* in_ptr_0, half* out_ptr_0, half* out_ptr_1) {
  std::vector<int64_t> input0_shape;
  input0_shape.resize(3);
  input0_shape[0] = input0_dim0;
  input0_shape[1] = input0_dim1;
  input0_shape[2] = input0_dim2;

  std::vector<int64_t> input1_shape;
  input1_shape.resize(2);
  input1_shape[0] = input0_dim2;
  input1_shape[1] = input1_dim1;

  cudaStream_t* cuda_stream_ptr = reinterpret_cast<cudaStream_t*>(stream_ptr);
  ap::GemmEpilogueParams params(
      *cuda_stream_ptr, input0, input1, nullptr, output, input0_shape, input1_shape, std::vector<int64_t>{});

#if AP_ENABLE_AUTOTUNE
  AP_AUTOTUNE_half(ap::RunMatmulWithVariadicKernel, *cuda_stream_ptr, params, input0, input1, output, input0_dim0, input0_dim1, input0_dim2, input1_dim1, in_ptr_0, out_ptr_0, out_ptr_1);
#else
  ap::RunMatmulWithVariadicKernel<ap::DefaultConfig::kConfigId>(params, input0, input1, output, input0_dim0, input0_dim1, input0_dim2, input1_dim1, in_ptr_0, out_ptr_0, out_ptr_1);
#endif
}
}
} // namespace ap
```