### PR TITLE
Fix output register definition in epilogue and codegen of store_to_global.

### DIFF
--- a/tests/ap/matmul_binary_tpl.py
+++ b/tests/ap/matmul_binary_tpl.py
@@ -97,11 +97,6 @@ class MatmulBinaryTemplate:
             lambda pair: pair[0].runtime_getter, all_kernel_arg_id_and_unique_names
         )
 
-    def init_outputs(self):
-        out_tensor_data_nums = self.mut_kernel_arg_id_registry.out_tensor_data_ptr_seq_no + 1
-        stmt = map(lambda i: f"out{i}", range(out_tensor_data_nums))
-        return "T " + f", ".join(stmt) + ";"
-
     def get_kernel_arg_types(self):
         all_kernel_arg_id_and_unique_names = (
             self.mut_kernel_arg_id_registry.all_kernel_arg_id2unique_name.items()
@@ -213,9 +208,9 @@ struct VariadicEpilogueFunctor {
   // Note: need to support vectorized operation
   __forceinline__ __host__ __device__
   T operator()(T x, const Arguments& args, const MatrixCoord& coord) const {
-    ${AP_OUTPUTS_INIT}
+    T out;
     ${AP_EPILOGUE_COMPUTATION_STATEMENTS}
-    return out0;
+    return out;
   }
 };
 
@@ -265,7 +260,6 @@ void ${kernel_name}(void* stream_ptr, ${AP_KERNEL_ARGS_DECLARE}) {
             code_template.replace(
                 "${AP_EPILOGUE_COMPUTATION_STATEMENTS}", trivial_code_str
             )
-            .replace("${AP_OUTPUTS_INIT}", self.init_outputs())
             .replace(
                 "${AP_KERNEL_ARGS_DECLARE}",
                 self.get_kernel_arg_list_str(for_declare=True),

--- a/tests/ap/op_compute_translator_util.py
+++ b/tests/ap/op_compute_translator_util.py
@@ -112,6 +112,7 @@ class ApOpStoreToGlobalCodeGen:
       mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
       mut_lir_code_gen_ctx=mut_lir_code_gen_ctx,
     )
+    arg_name = mut_kernel_arg_id_registry.get_out_tensor_data_ptr_var_name(index_func_unique_id)
     glb_data_type = self.get_glb_type(mut_kernel_arg_id_registry, index_func_unique_id)
     ptr_var_name = self.kernel_arg_translator.get_use_name(arg_name)
     mut_lir_code_gen_ctx.store(glb_data_type, ptr_var_name, offset_var_name, inputs[1].var_name)
@@ -587,8 +588,9 @@ class OpComputeTranslatorFactory:
   def __init__(self):
     self.op_name2class = OrderedDict([
       ["ap_op.load_from_register",  ApOpLoadFromRegisterCodeGen],
-      ["ap_op.store_to_register",   ApOpStoreToRegisterCodeGen],
       ["ap_op.load_from_global",    ApOpLoadFromGlobalCodeGen],
+      ["ap_op.store_to_register",   ApOpStoreToRegisterCodeGen],
+      ["ap_op.store_to_global",     ApOpStoreToGlobalCodeGen],
       ["pd_op.data",                PdOpDataCodeGen],
       ["pd_op.full",                PdOpFullCodeGen],
       ["pd_op.cast",                PdOpCastCodeGen],

--- a/tests/ap/test_matmul_binary.py
+++ b/tests/ap/test_matmul_binary.py
@@ -201,11 +201,11 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
     mut_program = ir_tools.copy_fused_ops_to_program(
       o.trivial_op, tensor_match_ctx=t
     )
-    # umprime passes
     pass_manager = ir_tools.create_pass_manager()
     pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("umprime"))
     pass_manager.add_pass(ir_tools.create_dce_pass())
     pass_manager.run(mut_program)
+    print("after-umprime:\n", mut_program)
     self._insert_load_from_global(
       mut_program,
       input_names=["mm_out", "input2"]
@@ -214,6 +214,7 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
       mut_program,
       output_names=["output"]
     )
+    print("after-insert_load_and_store:\n", mut_program)
     kernel_arg_translator = self._make_kernel_arg_translator()
     index_func_unique_id2index_program = self._make_index_func_unique_id2index_program(
       mut_program,

--- a/tests/ap/test_matmul_epilogue.py
+++ b/tests/ap/test_matmul_epilogue.py
@@ -219,7 +219,6 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
       o.trivial_op, tensor_match_ctx=t
     )
     print("before-umprime: ", mut_program)
-    # umprime passes
     pass_manager = ir_tools.create_pass_manager()
     pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("umprime"))
     pass_manager.add_pass(ir_tools.create_dce_pass())
@@ -254,7 +253,7 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
       load_ir_value_name="mm_out",
       register_var_name="x"
     )
-    self._replace_with_store_to_register(mut_program, "output0", "out0")
+    self._replace_with_store_to_register(mut_program, "output0", "out")
     print("mut_program:", mut_program)
     op_compute_translator_maker = op_compute_translator_util.OpComputeTranslatorFactory()
     print('berfore translator')


### PR DESCRIPTION
针对 https://github.com/lixinqi/Athena/pull/20 支持多输入多输出功能，进行补充：

- 如https://github.com/lixinqi/Athena/pull/20#discussion_r2043854624 ，`${AP_OUTPUTS_INIT}` 并不需要了，对这部分修改进行revert。
- 修复`ApOpStoreToGlobalCodeGen`，并添加到`OpComputeTranslatorFactory`，从而可以支持Epilogue中写回显存。