### PR TITLE
Support mm_out as right add, such as `data + mm_out`.

### DIFF
--- a/tests/ap/paddle-tests/test_matmul_epilogue.py
+++ b/tests/ap/paddle-tests/test_matmul_epilogue.py
@@ -23,23 +23,31 @@ import paddle
 from paddle.static import InputSpec
 
 
-def trivial_matrix_binary(x, y, b):
-    out = paddle.matmul(x, y)
-    bias = out - b
-    relu = paddle.nn.functional.relu(out)
-    exp = paddle.exp(relu)
-    return bias, relu, exp
+def matmul_add_left_add(x, y, b, another):
+    mm_out = paddle.matmul(x, y)
+    bias_out = mm_out + b
+    out = bias_out + another
+    return bias_out, out
+
+
+def matmul_add_right_add(x, y, b, another):
+    mm_out = paddle.matmul(x, y)
+    bias_out = mm_out + b
+    out = another + bias_out
+    return bias_out, out
+
 
 class CINNSubGraphNet(paddle.nn.Layer):
     def __init__(self, fn):
         super().__init__()
         self.fn = fn
 
-    def forward(self, x, y, b):
-        out = self.fn(x, y, b)
-        return out
+    def forward(self, x, y, b, another):
+        outs = self.fn(x, y, b, another)
+        return outs
 
-class TestAPMatmulBinaryTriangleShape(unittest.TestCase):
+
+class TestAPMatmulTernary(unittest.TestCase):
     """
     Test Pir API + @to_static + CINN.
     """
@@ -59,30 +67,44 @@ class TestAPMatmulBinaryTriangleShape(unittest.TestCase):
         self.y = paddle.randn(self.y_shape, dtype=self.dtype)
         self.y.stop_gradient = False
 
-        # self.b_shape = [4, 65536, 32]
         self.b_shape = [32]
         self.b = paddle.randn(self.b_shape, dtype=self.dtype)
         self.b.stop_gradient = False
 
-    def eval_symbolic(self, use_cinn, profile):
-        net = CINNSubGraphNet(trivial_matrix_binary)
+        self.another_shape = [32]
+        self.another = paddle.randn(self.another_shape, dtype=self.dtype)
+        self.another.stop_gradient = False
+
+    def eval_symbolic(self, net, use_cinn, profile):
         input_spec = [
             InputSpec(shape=self.x_shape, dtype=self.dtype),
             InputSpec(shape=self.y_shape, dtype=self.dtype),
             InputSpec(shape=self.b_shape, dtype=self.dtype),
+            InputSpec(shape=self.another_shape, dtype=self.dtype),
         ]
         net = utils.apply_to_static(net, use_cinn, input_spec)
         net.eval()
-        out = utils.run_with_profile(profile, net, self.x, self.y, self.b)
+        out = utils.run_with_profile(profile, net, self.x, self.y, self.b, self.another)
         return out
 
-    def test_eval_symbolic(self):
+    def test_matmul_add_right_add(self):
         profile = False
-        cinn_out = self.eval_symbolic(use_cinn=True, profile=profile)
-        dy_out = self.eval_symbolic(use_cinn=False, profile=profile)
+        net = CINNSubGraphNet(matmul_add_right_add)
+        cinn_outs = self.eval_symbolic(net, use_cinn=True, profile=profile)
+        dy_outs = self.eval_symbolic(net, use_cinn=False, profile=profile)
         if not profile:
-            for i,(a,b) in enumerate(zip(cinn_out,dy_out)):
+            for i, (a, b) in enumerate(zip(cinn_outs, dy_outs)):
                 utils.check_result(self.dtype, a.numpy(), b.numpy())
+
+    def test_matmul_add_left_add(self):
+        profile = False
+        net = CINNSubGraphNet(matmul_add_left_add)
+        cinn_outs = self.eval_symbolic(net, use_cinn=True, profile=profile)
+        dy_outs = self.eval_symbolic(net, use_cinn=False, profile=profile)
+        if not profile:
+            for i, (a, b) in enumerate(zip(cinn_outs, dy_outs)):
+                utils.check_result(self.dtype, a.numpy(), b.numpy())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/ap/topo_drr_pass.py
+++ b/tests/ap/topo_drr_pass.py
@@ -355,7 +355,7 @@ class DownSpiderUpSpiderAccessTopoPass(access_topo_drr.DrrPass):
 
 
 @access_topo_drr.register_drr_pass("left_down_spider_add", tag="default")
-class DownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
+class LeftDownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):
     o.spider = o.ap_native_op("ap_op.down_spider")
@@ -365,7 +365,7 @@ class DownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
     )
     o.add = o.ap_native_op("pd_op.add")
     o.add(
-      [t.tmp0, t.tmp1],
+      [t.tmp0, t.input1],
       [t.output]
     )
 
@@ -377,12 +377,12 @@ class DownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
     )
     o.up_spider = o.ap_native_op("ap_op.up_spider")
     o.up_spider(
-      [t.input0, t.tmp1],
+      [t.input0, t.input1],
       []
     )
 
 @access_topo_drr.register_drr_pass("right_down_spider_add", tag="default")
-class DownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
+class RightDownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):
     o.spider = o.ap_native_op("ap_op.down_spider")
@@ -392,7 +392,7 @@ class DownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
     )
     o.add = o.ap_native_op("pd_op.add")
     o.add(
-      [t.tmp1, t.tmp0],
+      [t.input1, t.tmp0],
       [t.output]
     )
 
@@ -404,7 +404,7 @@ class DownSpiderAddAccessTopoPass(access_topo_drr.DrrPass):
     )
     o.up_spider = o.ap_native_op("ap_op.up_spider")
     o.up_spider(
-      [t.tmp1, t.input0],
+      [t.input0, t.input1],
       []
     )
 


### PR DESCRIPTION
`up_spider(input0, input1)`的两个输入的语义是不一样的，`input0`代表已经处理好的一支，`input1`代表需要继续向上深入去处理的一支，其中可能存在广播、规约等操作。故当前的`right_down_spider_add`中`result_pattern`里面的`up_spider`两个输入写反了。

本PR修复后，可支持`another + (mm_out + b)`这种`mm_out`作为`add`第一个输入的子图。
