### PR TITLE
Add a pattern for handling the matmul_epilogue_with_mm_out

### DIFF
--- a/tests/ap/test_matmul_epilogue_with_mm_out.py
+++ b/tests/ap/test_matmul_epilogue_with_mm_out.py
@@ -107,6 +107,12 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
     init_pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(ir_pass))
     init_pass_manager.run(program)
 
+  def _insert_store_to_global_mm(self, program):
+    init_pass_manager = ir_tools.create_pass_manager()
+    ir_pass = topo_drr_pass.InsertStoreToGlobalForMMoutAccessTopoPass()
+    init_pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(ir_pass))
+    init_pass_manager.run(program)
+
   def _make_kernel_arg_translator(self):
     return matmul_binary_tpl.make_kernel_arg_translator()
 
@@ -210,7 +216,7 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
     return mut_program
 
   def _get_program_translator(self, ctx, o, t):
-    other_outputs_name_list = map(lambda i: f"output{i+1}", range(self.number_of_outputs()-1))
+    other_outputs_name_list = [*map(lambda i: f"output{i+1}", range(self.number_of_outputs()-1)), "mm_out"]
     inputs_name_list = map(lambda i: f"input{i+2}", range(self.number_of_inputs() - 2)) if self.number_of_inputs() > 2 else []
     mut_program = ir_tools.copy_fused_ops_to_program(
       o.trivial_op, tensor_match_ctx=t
@@ -231,6 +237,9 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
     self._replace_yeild_with_store_to_global(
       mut_program,
       output_names=map(lambda i: f"output{i}", range(self.number_of_outputs()))
+    )
+    self._insert_store_to_global_mm(
+      mut_program,
     )
     kernel_arg_translator = self._make_kernel_arg_translator()
     index_func_unique_id2index_program = self._make_index_func_unique_id2index_program(

--- a/tests/ap/topo_drr_pass.py
+++ b/tests/ap/topo_drr_pass.py
@@ -136,6 +136,66 @@ class FakeDataStoreToGlobalForYieldAccessTopoPass(access_topo_drr.DrrPass):
       []
     )
 
+class InsertStoreToGlobalForMMoutAccessTopoPass(access_topo_drr.DrrPass):
+
+  def __init__(self):
+    self.undefined_place = pir.a_place(pir.UndefinedPlace())
+    self.data_input_name_attr = pir.a_str('mm_out')
+
+  def source_pattern(self, o, t):
+    o.load_from_global = o.ap_native_op("ap_op.load_from_global")
+    o.load_from_global(
+      [t.mm_out],
+      [t.mm_local_out]
+    )
+
+  def constraint(self, o, t):
+    return o.load_from_global.index_func_unique_id == self.data_input_name_attr
+
+  def result_pattern(self, o, t):
+    t.declare_internal_native_ir_value("input")
+    self.result_pattern_data_op(o, t)
+    store_to_global_op_name = "store_to_global_mm_op"
+    setattr(o, store_to_global_op_name, o.ap_native_op("ap_op.store_to_global"))
+    store_to_global_op = getattr(o, store_to_global_op_name)
+    store_to_global_op.index_func_unique_id = lambda o, t: self.data_input_name_attr
+    store_to_global_op(
+      [t.mm_out, t.mm_local_out],
+      []
+    )
+
+  def result_pattern_data_op(self, o, t):
+    t.declare_internal_native_ir_value(f"mm_out")
+    data_op_unique_name = f"data_op_for_mm_output"
+    setattr(o, data_op_unique_name, o.ap_native_op("pd_op.data"))
+    data_op = getattr(o, data_op_unique_name)
+    data_op.name = lambda o, t: self.get_name(o, t)
+    data_op.shape = lambda o, t: self.get_shape(o, t)
+    data_op.dtype = lambda o, t: self.get_dtype(o, t)
+    data_op.place = lambda o, t: self.get_place(o, t)
+    data_op(
+      [],
+      [t.mm_out]
+    )
+
+  def get_name(self, o, t):
+    return pir.a_str("mm_glb_out")
+
+  def get_shape(self, o, t):
+    ir_tensor = getattr(t, "mm_out")
+    def GetDims(dtype, dims, data_layout):
+      return dims
+    return pir.a_intarray(ir_tensor.type.match(t_dtensor=GetDims))
+
+  def get_dtype(self, o, t):
+    ir_tensor = getattr(t, "mm_out")
+    def GetDtype(dtype, dims, data_layout):
+      return dtype
+    return pir.a_dtype(ir_tensor.type.match(t_dtensor=GetDtype))
+
+  def get_place(self, o, t):
+      return self.undefined_place
+
 class ConvertUpSpiderStoreDataOpToYieldOpPass(access_topo_drr.DrrPass):
 
   def source_pattern(self, o, t):


### PR DESCRIPTION
在matmul_epilogue模板基础上，增加一个独立的模板 matmul_epilogue_with_mm_out， 用来暂时支持mm_out输出，如果需要在输出mm_out 与 不输出 之间切换，可以手动替换在make_axpr, __main__中使用的模板名称。