### PR TITLE
Support non-3d tensors.

### DIFF
--- a/tests/ap/index_code_gen_value_util.py
+++ b/tests/ap/index_code_gen_value_util.py
@@ -1,4 +1,5 @@
 class IndexCodeGenValue:
-  def __init__(self, iter_var_names):
+  def __init__(self, iter_var_names, iter_dim_splits):
     self.iter_var_names = iter_var_names
+    self.iter_dim_splits = iter_dim_splits
     self.const_data = None

--- a/tests/ap/index_program_translator_util.py
+++ b/tests/ap/index_program_translator_util.py
@@ -8,10 +8,12 @@ class IndexProgramTranslatorMap:
     self,
     index_func_unique_id2index_program,
     kernel_arg_translator,
-    anchor_iter_var_names
+    anchor_iter_var_names,
+    anchor_iter_dim_splits
   ):
     self.kernel_arg_translator = kernel_arg_translator
     self.anchor_iter_var_names = anchor_iter_var_names
+    self.anchor_iter_dim_splits = anchor_iter_dim_splits
     items = index_func_unique_id2index_program.items()
     self.index_func_unique_id2translator = OrderedDict(
       map(
@@ -39,12 +41,14 @@ class IndexProgramTranslatorMap:
     pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
     pass_manager.add_pass(ir_tools.create_dce_pass())
     pass_manager.run(index_program)
+    print(f"index_program_with_reshape: {index_program}")
     return IndexProgramTranslator(
       index_program,
       program_id=program_id,
       kernel_arg_translator=self.kernel_arg_translator,
       index_op_translator_maker=op_index_translator_util.OpIndexTranslatorFactory(),
-      anchor_iter_var_names=self.anchor_iter_var_names
+      anchor_iter_var_names=self.anchor_iter_var_names,
+      anchor_iter_dim_splits=self.anchor_iter_dim_splits,
     )
 
 
@@ -56,13 +60,15 @@ class IndexProgramTranslator:
     program_id,
     kernel_arg_translator,
     index_op_translator_maker,
-    anchor_iter_var_names
+    anchor_iter_var_names,
+    anchor_iter_dim_splits
   ):
     self.program_id = program_id
     self.program_property = index_program.copy_to_const_program_data()
     self.kernel_arg_translator = kernel_arg_translator
     self.index_op_translator_maker = index_op_translator_maker
     self.anchor_iter_var_names = anchor_iter_var_names
+    self.anchor_iter_dim_splits = anchor_iter_dim_splits
     self.ir_value_index2translated_value = MutableList()
     def PushNone(x):
       self.ir_value_index2translated_value.append(None)
@@ -85,7 +91,8 @@ class IndexProgramTranslator:
       input_properties=map(self._get_value_property, op_property.input_value_indexes),
       output_properties=map(self._get_value_property, op_property.output_value_indexes),
       kernel_arg_translator=self.kernel_arg_translator,
-      anchor_iter_var_names=self.anchor_iter_var_names
+      anchor_iter_var_names=self.anchor_iter_var_names,
+      anchor_iter_dim_splits=self.anchor_iter_dim_splits
     )
     inputs = map(self._get_translated_value, op_property.input_value_indexes)
     outputs = index_op_translator(

--- a/tests/ap/index_program_translator_util.py
+++ b/tests/ap/index_program_translator_util.py
@@ -41,7 +41,6 @@ class IndexProgramTranslatorMap:
     pass_manager.add_pass(ir_tools.create_access_topo_drr_one_step_pass(drr_pass))
     pass_manager.add_pass(ir_tools.create_dce_pass())
     pass_manager.run(index_program)
-    print(f"index_program_with_reshape: {index_program}")
     return IndexProgramTranslator(
       index_program,
       program_id=program_id,

--- a/tests/ap/matmul_binary_tpl.py
+++ b/tests/ap/matmul_binary_tpl.py
@@ -10,6 +10,14 @@ def get_anchor_iter_var_names():
     return ["coord.batch", "coord.row", "coord.column"]
 
 
+def get_anchor_iter_dim_splits(symbolic_shape):
+    num_anchor_iters = len(get_anchor_iter_var_names())
+    diff = len(symbolic_shape) - num_anchor_iters
+    def get_dim_split(i):
+        return diff + 1 if i < diff else 1
+    return map(lambda i: get_dim_split(i), range(num_anchor_iters))
+
+
 class MatmulBinaryTemplate:
     def __init__(
         self,

--- a/tests/ap/matmul_binary_tpl.py
+++ b/tests/ap/matmul_binary_tpl.py
@@ -6,15 +6,22 @@ def make_kernel_arg_translator():
     return kernel_arg_translator_util.KernelArgTranslator(param_struct_name="args")
 
 
-def get_anchor_iter_var_names():
-    return ["coord.batch", "coord.row", "coord.column"]
+def get_anchor_iter_var_names(symbolic_shape):
+    return (
+        ["coord.batch", "coord.row", "coord.column"]
+        if len(symbolic_shape) >= 3
+        else ["coord.row", "coord.column"]
+    )
 
 
 def get_anchor_iter_dim_splits(symbolic_shape):
-    num_anchor_iters = len(get_anchor_iter_var_names())
+    num_anchor_iters = len(get_anchor_iter_var_names(symbolic_shape))
     diff = len(symbolic_shape) - num_anchor_iters
+
     def get_dim_split(i):
-        return diff + 1 if i < diff else 1
+        # 0 is batch which may have no dimension or multiple dimensions in symbolic_shape
+        return diff + 1 if i < num_anchor_iters - 2 else 1
+
     return map(lambda i: get_dim_split(i), range(num_anchor_iters))
 
 

--- a/tests/ap/op_index_translator_util.py
+++ b/tests/ap/op_index_translator_util.py
@@ -1,5 +1,6 @@
 import index_code_gen_value_util
 
+
 class PdOpDataCodeGen:
   def __init__(self,
                index_program_id,
@@ -7,16 +8,21 @@ class PdOpDataCodeGen:
                input_properties,
                output_properties,
                kernel_arg_translator,
-               anchor_iter_var_names):
+               anchor_iter_var_names,
+               anchor_iter_dim_splits):
     self.index_program_id = index_program_id
     self.op_property = op_property
     self.input_properties = input_properties
     self.output_properties = output_properties
     self.kernel_arg_translator = kernel_arg_translator
     self.anchor_iter_var_names = anchor_iter_var_names
+    self.anchor_iter_dim_splits = anchor_iter_dim_splits
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
-    return [index_code_gen_value_util.IndexCodeGenValue(self.anchor_iter_var_names)]
+    return [index_code_gen_value_util.IndexCodeGenValue(
+      self.anchor_iter_var_names,
+      self.anchor_iter_dim_splits
+    )]
 
 
 class PdOpFullIntArrayCodeGen:
@@ -26,16 +32,18 @@ class PdOpFullIntArrayCodeGen:
                input_properties,
                output_properties,
                kernel_arg_translator,
-               anchor_iter_var_names):
+               anchor_iter_var_names,
+               anchor_iter_dim_splits):
     self.index_program_id = index_program_id
     self.op_property = op_property
     self.input_properties = input_properties
     self.output_properties = output_properties
     self.kernel_arg_translator = kernel_arg_translator
     self.anchor_iter_var_names = anchor_iter_var_names
+    self.anchor_iter_dim_splits = anchor_iter_dim_splits
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
-    out = index_code_gen_value_util.IndexCodeGenValue(None)
+    out = index_code_gen_value_util.IndexCodeGenValue(None, None)
     def get_int64(attr):
       return attr.match(a_i64=lambda x:x)
     def convert_list(lst):
@@ -45,6 +53,7 @@ class PdOpFullIntArrayCodeGen:
     )
     return [out]
 
+
 class PdOpSumCodeGen:
   def __init__(self,
                index_program_id,
@@ -52,28 +61,51 @@ class PdOpSumCodeGen:
                input_properties,
                output_properties,
                kernel_arg_translator,
-               anchor_iter_var_names):
+               anchor_iter_var_names,
+               anchor_iter_dim_splits):
     self.index_program_id = index_program_id
     self.op_property = op_property
     self.input_properties = input_properties
     self.output_properties = output_properties
     self.kernel_arg_translator = kernel_arg_translator
     self.anchor_iter_var_names = anchor_iter_var_names
+    self.anchor_iter_dim_splits = anchor_iter_dim_splits
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
     input_iter_var_names = inputs[0].iter_var_names
-    reduced_axes_set = OrderedDict(
-      map(lambda x: [int(x), True], inputs[1].const_data)
+    input_iter_dim_splits = inputs[0].iter_dim_splits
+    def is_reduced_axes(dim):
+      return False if len(filter(lambda x: int(x) == dim, inputs[1].const_data)) == 0 else True
+    input_dim_split_starts = MutableList()
+    input_dim_split_starts.append(0)
+    def is_anchor_reduced_axes(i):
+      dim_split_start = int(input_dim_split_starts[i])
+      dim_split_stop = dim_split_start + input_iter_dim_splits[i]
+      input_dim_split_starts.append(dim_split_stop)
+      is_reduced_axes_result = filter(
+        lambda dim: is_reduced_axes(dim), range(dim_split_start, dim_split_stop)
+      ) 
+      return False if len(is_reduced_axes_result) == 0 else True
+    anchor_reduced_axes_set = OrderedDict(
+      map(lambda i: [i, is_anchor_reduced_axes(i)],
+      range(len(input_iter_dim_splits)))
     )
-    non_reduced_axes = filter(
-      lambda x: reduced_axes_set.contains(x) == False,
+    anchor_non_reduced_axes = filter(
+      lambda x: anchor_reduced_axes_set[x] == False,
       range(len(input_iter_var_names))
     )
     output_iter_var_names = map(
       lambda i: input_iter_var_names[i],
-      non_reduced_axes
+      anchor_non_reduced_axes
     )
-    return [index_code_gen_value_util.IndexCodeGenValue(output_iter_var_names)]
+    output_iter_dim_splits = map(
+      lambda i: input_iter_dim_splits[i],
+      anchor_non_reduced_axes
+    )
+    return [index_code_gen_value_util.IndexCodeGenValue(
+      output_iter_var_names,
+      output_iter_dim_splits
+    )]
 
 
 class CinnOpReshapeCodeGen:
@@ -83,25 +115,38 @@ class CinnOpReshapeCodeGen:
                input_properties,
                output_properties,
                kernel_arg_translator,
-               anchor_iter_var_names):
+               anchor_iter_var_names,
+               anchor_iter_dim_splits):
     self.index_program_id = index_program_id
     self.op_property = op_property
     self.input_properties = input_properties
     self.output_properties = output_properties
     self.kernel_arg_translator = kernel_arg_translator
     self.anchor_iter_var_names = anchor_iter_var_names
+    self.anchor_iter_dim_splits = anchor_iter_dim_splits
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
     symbolic_shape = self.input_properties[0].symbolic_shape
-    def get_or_create_dim_var_name(dim_expr):
-      arg_var_name = mut_kernel_arg_id_registry.get_dim_expr_var_name(dim_expr)
-      return self.kernel_arg_translator.get_use_name(arg_var_name)
+    input_iter_var_names = inputs[0].iter_var_names
+    input_iter_dim_splits = inputs[0].iter_dim_splits
     def get_dim_var_name(i):
       dim_expr = symbolic_shape[i]
-      return get_or_create_dim_var_name(dim_expr)
-    rank = len(symbolic_shape)
+      arg_var_name = mut_kernel_arg_id_registry.get_dim_expr_var_name(dim_expr)
+      return self.kernel_arg_translator.get_use_name(arg_var_name)
+    input_dim_split_starts = MutableList()
+    input_dim_split_starts.append(0)
+    def get_anchor_iter_dims(i):
+      dim_split_start = int(input_dim_split_starts[i])
+      dim_split_stop = dim_split_start + input_iter_dim_splits[i]
+      input_dim_split_starts.append(dim_split_stop)
+      current_dim_names = map(
+        lambda idx: get_dim_var_name(idx), range(dim_split_start, dim_split_stop)
+      )
+      return " * ".join(current_dim_names)
+    rank = len(input_iter_dim_splits)
+    anchor_iter_dims = map(lambda i : get_anchor_iter_dims(i), range(rank))
     stride_dims_list = map(
-      lambda num_dims: map(lambda i: get_dim_var_name(num_dims + i + 1), range(rank - 1 - num_dims)),
+      lambda num_dims: map(lambda i: anchor_iter_dims[num_dims + i + 1], range(rank - 1 - num_dims)),
       range(rank)
     )
     var_name_and_dims_list = map(
@@ -115,7 +160,10 @@ class CinnOpReshapeCodeGen:
       )
     )
     assert len(self.output_properties[0].symbolic_shape) == 1, "len(self.output_properties[0]) should be 1"
-    return [index_code_gen_value_util.IndexCodeGenValue([f"({offset_expr})"])]
+    return [index_code_gen_value_util.IndexCodeGenValue(
+      [f"({offset_expr})"],
+      input_iter_dim_splits)
+    ]
 
 
 class CfYieldCodeGen:
@@ -125,13 +173,15 @@ class CfYieldCodeGen:
                input_properties,
                output_properties,
                kernel_arg_translator,
-               anchor_iter_var_names):
+               anchor_iter_var_names,
+               anchor_iter_dim_splits):
     self.index_program_id = index_program_id
     self.op_property = op_property
     self.input_properties = input_properties
     self.output_properties = output_properties
     self.kernel_arg_translator = kernel_arg_translator
     self.anchor_iter_var_names = anchor_iter_var_names
+    self.anchor_iter_dim_splits = anchor_iter_dim_splits
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
     return []
@@ -153,7 +203,8 @@ class OpIndexTranslatorFactory:
                input_properties,
                output_properties,
                kernel_arg_translator,
-               anchor_iter_var_names):
+               anchor_iter_var_names,
+               anchor_iter_dim_splits):
     cls = self._get_class(op_property.op_name)
     return cls(
       index_program_id=index_program_id,
@@ -162,6 +213,7 @@ class OpIndexTranslatorFactory:
       output_properties=output_properties,
       kernel_arg_translator=kernel_arg_translator,
       anchor_iter_var_names=anchor_iter_var_names,
+      anchor_iter_dim_splits=anchor_iter_dim_splits,
     )
 
   def _get_class(self, op_name):

--- a/tests/ap/op_index_translator_util.py
+++ b/tests/ap/op_index_translator_util.py
@@ -19,6 +19,7 @@ class PdOpDataCodeGen:
     self.anchor_iter_dim_splits = anchor_iter_dim_splits
 
   def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    assert len(self.anchor_iter_var_names) == len(self.anchor_iter_dim_splits), "The length of anchor_iter_var_names and anchor_iter_dim_splits is expected to be the same."
     return [index_code_gen_value_util.IndexCodeGenValue(
       self.anchor_iter_var_names,
       self.anchor_iter_dim_splits
@@ -86,12 +87,8 @@ class PdOpSumCodeGen:
         lambda dim: is_reduced_axes(dim), range(dim_split_start, dim_split_stop)
       ) 
       return False if len(is_reduced_axes_result) == 0 else True
-    anchor_reduced_axes_set = OrderedDict(
-      map(lambda i: [i, is_anchor_reduced_axes(i)],
-      range(len(input_iter_dim_splits)))
-    )
     anchor_non_reduced_axes = filter(
-      lambda x: anchor_reduced_axes_set[x] == False,
+      lambda i: is_anchor_reduced_axes(i) == False,
       range(len(input_iter_var_names))
     )
     output_iter_var_names = map(

--- a/tests/ap/test_matmul_binary.py
+++ b/tests/ap/test_matmul_binary.py
@@ -223,10 +223,12 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
       output_names=[],
     )
     print("index_func_unique_id2index_program:\n", index_func_unique_id2index_program)
+    mm_out_symbolic_shape = t.mm_out.symbolic_shape_to_list()
     index_program_translator_map = index_program_translator_util.IndexProgramTranslatorMap(
       index_func_unique_id2index_program=index_func_unique_id2index_program,
       kernel_arg_translator=kernel_arg_translator,
-      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names()
+      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names(),
+      anchor_iter_dim_splits=matmul_binary_tpl.get_anchor_iter_dim_splits(mm_out_symbolic_shape),
     )
     self._replace_with_load_from_register(
       mut_program,

--- a/tests/ap/test_matmul_binary.py
+++ b/tests/ap/test_matmul_binary.py
@@ -227,7 +227,7 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
     index_program_translator_map = index_program_translator_util.IndexProgramTranslatorMap(
       index_func_unique_id2index_program=index_func_unique_id2index_program,
       kernel_arg_translator=kernel_arg_translator,
-      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names(),
+      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names(mm_out_symbolic_shape),
       anchor_iter_dim_splits=matmul_binary_tpl.get_anchor_iter_dim_splits(mm_out_symbolic_shape),
     )
     self._replace_with_load_from_register(

--- a/tests/ap/test_matmul_epilogue.py
+++ b/tests/ap/test_matmul_epilogue.py
@@ -43,7 +43,6 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
   def constraint(self, o, t):
     program = ir_tools.copy_fused_ops_to_program(o.trivial_op, tensor_match_ctx=t)
     print("before-umprime: ", program)
-    # umprime passes
     pass_manager = ir_tools.create_pass_manager()
     pass_manager.add_pass(ir_tools.create_access_topo_drr_pass("umprime"))
     pass_manager.add_pass(ir_tools.create_dce_pass())
@@ -56,7 +55,6 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
     )
     outputs_name_list = map(lambda i: f"output{i}", range(self.number_of_outputs()))
     inputs_name_list = map(lambda i: f"input{i+2}", range(self.number_of_inputs() - 2)) if self.number_of_inputs() > 2 else []
-    print('inputs_name_list: ', ', '.join(inputs_name_list))
     init_fake_data_for_yield_input = topo_drr_pass.FakeDataForYieldAccessTopoPass(
       outputs_name_list
     )
@@ -243,10 +241,12 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
       output_names=other_outputs_name_list,
     )
     print("index_func_unique_id2index_program:\n", index_func_unique_id2index_program)
+    mm_out_symbolic_shape = t.mm_out.symbolic_shape_to_list()
     index_program_translator_map = index_program_translator_util.IndexProgramTranslatorMap(
       index_func_unique_id2index_program=index_func_unique_id2index_program,
       kernel_arg_translator=kernel_arg_translator,
-      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names()
+      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names(mm_out_symbolic_shape),
+      anchor_iter_dim_splits=matmul_binary_tpl.get_anchor_iter_dim_splits(mm_out_symbolic_shape),
     )
     self._replace_with_load_from_register(
       mut_program,


### PR DESCRIPTION
### 背景
AP系统当前只支持了3-D输入，非3-D输入在生成Epilogue index计算代码的时候会报错。针对非3-D输入，有2种解决思路（以如下子图结构为例）：
```python
{
    (%0) = "pd_op.data" () {dtype:float16,name:"x",place:Place(undefined:0),shape:[4,16,4096,128],stop_gradient:[false]} : () -> tensor<4x16x4096x128xf16>
    (%1) = "pd_op.data" () {dtype:float16,name:"y",place:Place(undefined:0),shape:[128,32],stop_gradient:[false]} : () -> tensor<128x32xf16>                                        
    (%2) = "pd_op.data" () {dtype:float16,name:"b",place:Place(undefined:0),shape:[4,16,4096,32],stop_gradient:[false]} : () -> tensor<4x16x4096x32xf16>
    (%3) = "pd_op.matmul" (%0, %1) {stop_gradient:[false],transpose_x:false,transpose_y:false} : (tensor<4x16x4096x128xf16>, tensor<128x32xf16>) -> tensor<4x16x4096x32xf16>
    (%4) = "cinn_op.fusion" () -> tensor<4x16x4096x32xf16> {
        (%5) = "pd_op.add" (%3, %2) {stop_gradient:[false]} : (tensor<4x16x4096x32xf16>, tensor<4x16x4096x32xf16>) -> tensor<4x16x4096x32xf16>
        (%6) = "pd_op.full" () {dtype:float16,place:Place(undefined:0),shape:[4,16,4096,32],stop_gradient:[true],value:0} : () -> tensor<4x16x4096x32xf16>
        (%7) = "pd_op.maximum" (%5, %6) {comp_op_name:"pd_op.relu",stop_gradient:[false]} : (tensor<4x16x4096x32xf16>, tensor<4x16x4096x32xf16>) -> tensor<4x16x4096x32xf16>
        () = "cf.yield" (%7) {} : (tensor<4x16x4096x32xf16>) ->  
    }   
    () = "builtin.shadow_output" (%4) {output_name:"output_0"} : (tensor<4x16x4096x32xf16>) ->  
}
```

- 生成代码时，在子图前后插入reshape算子。涉及的工作包括：
  1. 插入2个reshape算子，要准确地计算好reshape算子的目标shape，变换后如下
![image](https://github.com/user-attachments/assets/97d19336-b87a-450a-9704-cc3cf930ad13)

  2. 子图shape推导，更新其他算子的输入、输出Shape
  3. 针对full这类特殊算子，需要更新shape属性
  4. 添加reshape算子计算的代码生成器
- 根据实际shape修正index计算

### 解决方案
插入reshape算子方案工作量较大，且容易引入错误，所以本PR采取修正index计算的解决方案。具体思路如下：
- 当矩阵乘输入Tensor是2-D时，其实只有2个坐标，故修改`get_anchor_iter_var_names()`函数，只返回`["coord.row", "coord.column"]`。生成的Epilogue代码如下：
```cpp
    float op2_out0 = static_cast<float>(args.in_ptr_0[(coord.row * args.input1_dim1 + coord.column)]);
    float op3_out0 = static_cast<float>(x + op2_out0);
    float op4_out0 = static_cast<float>((op3_out0 > 0 ? op3_out0 : 0) );
    out = op4_out0;
```

- 当矩阵乘输入Tensor是4-D以上时，引入一个和`anchor_iter_var_names`一样长的list `anchor_iter_dim_splits`，来记录`anchor_iter_var_names`中每个坐标在原Tensor shape中占的维度的个数。
  - 对于4-D以上的Tensor，目前只支持`[b0, ..., bx, M, N]`，即前面`Rank-2`个维度都是`Batch`维度，因此`anchor_iter_dim_splits = [Rank - 2, 1, 1]`。针对`[b0, ..., bx, M0, ..., My, N0, ..., Nz]`的情况，后续也支持扩展。
  - `iter_dim_splits`也需要保存到`IndexCodeGenValue`中，sum算子的输出`iter_dim_splits`会发生改变。

