### PR TITLE
Rename MatmulBinaryTemplate/Kernel to MatmulVariadicTemplate/Kernel.

### DIFF
--- a/tests/ap/make_axpr.sh
+++ b/tests/ap/make_axpr.sh
@@ -18,7 +18,7 @@ FILENAMES_ARRAY=(
     "access_topo_drr"
     "abstract_drr"
     "ap_tpl_codegen"
-    "matmul_binary_tpl"
+    "matmul_variadic_tpl"
     "matmul_epilogue_pass"
     "test_matmul_binary"
     "test_matmul_epilogue"

--- a/tests/ap/matmul_variadic_tpl.py
+++ b/tests/ap/matmul_variadic_tpl.py
@@ -10,7 +10,7 @@ def get_anchor_iter_var_names():
     return ["coord.batch", "coord.row", "coord.column"]
 
 
-class MatmulBinaryTemplate:
+class MatmulVariadicTemplate:
     def __init__(
         self,
         program_translator,
@@ -31,8 +31,8 @@ class MatmulBinaryTemplate:
             ]
         )
         self.input_dim_karg_to_shape_access = MutableOrderedDict()
-        self.kernel_name = "MatmulBinaryKernel"
-        self.library_name = "matmul_binary_kernel"
+        self.kernel_name = "MatmulVariadicKernel"
+        self.library_name = "matmul_variadic_kernel"
 
     def _register_name(self, pair):
         registry = self.mut_kernel_arg_id_registry
@@ -333,7 +333,7 @@ void ${kernel_name}(void* stream_ptr, ${AP_KERNEL_ARGS_DECLARE}) {
 
 
 def KernelDispatch(ctx):
-    so_func = ctx.get_so_function("MatmulBinaryKernel")
+    so_func = ctx.get_so_function("MatmulVariadicKernel")
     stream_ptr = ctx.device_ctx.get_stream_addr_as_void_ptr()
     getters = ctx.kernel_dispatch_const_data.kernel_args_getters
     args = [stream_ptr, *map(lambda getter: getter(ctx), getters)]

--- a/tests/ap/test_matmul_binary.py
+++ b/tests/ap/test_matmul_binary.py
@@ -2,7 +2,7 @@ import abstract_drr
 import access_topo_drr
 import topo_drr_pass
 import op_convertion_drr_pass
-import matmul_binary_tpl
+import matmul_variadic_tpl
 import matmul_epilogue_pass
 import ir_tools
 import index_program_translator_util
@@ -102,7 +102,7 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
     init_pass_manager.run(program)
 
   def _make_kernel_arg_translator(self):
-    return matmul_binary_tpl.make_kernel_arg_translator()
+    return matmul_variadic_tpl.make_kernel_arg_translator()
 
   def _apply_topo_access_passes(self, mut_program, anchor_data_op_name):
     init_pass_manager = ir_tools.create_pass_manager()
@@ -226,7 +226,7 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
     index_program_translator_map = index_program_translator_util.IndexProgramTranslatorMap(
       index_func_unique_id2index_program=index_func_unique_id2index_program,
       kernel_arg_translator=kernel_arg_translator,
-      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names()
+      anchor_iter_var_names=matmul_variadic_tpl.get_anchor_iter_var_names()
     )
     self._replace_with_load_from_register(
       mut_program,
@@ -255,7 +255,7 @@ class MatmulBinaryFusion(abstract_drr.DrrPass):
       tensor_match_ctx=t,
       name_prefix=""
     )
-    template_module = matmul_binary_tpl.MatmulBinaryTemplate(
+    template_module = matmul_variadic_tpl.MatmulVariadicTemplate(
       program_translator=program_translator,
       mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
     )

--- a/tests/ap/test_matmul_epilogue.py
+++ b/tests/ap/test_matmul_epilogue.py
@@ -4,7 +4,7 @@ import topo_drr_pass
 import umprime
 import matmul_epilogue_pass
 import op_convertion_drr_pass
-import matmul_binary_tpl
+import matmul_variadic_tpl
 import ir_tools
 import index_program_translator_util
 import op_compute_translator_util
@@ -109,7 +109,7 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
     init_pass_manager.run(program)
 
   def _make_kernel_arg_translator(self):
-    return matmul_binary_tpl.make_kernel_arg_translator()
+    return matmul_variadic_tpl.make_kernel_arg_translator()
 
   def _apply_topo_access_passes(self, mut_program, anchor_data_op_name):
     init_pass_manager = ir_tools.create_pass_manager()
@@ -246,7 +246,7 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
     index_program_translator_map = index_program_translator_util.IndexProgramTranslatorMap(
       index_func_unique_id2index_program=index_func_unique_id2index_program,
       kernel_arg_translator=kernel_arg_translator,
-      anchor_iter_var_names=matmul_binary_tpl.get_anchor_iter_var_names()
+      anchor_iter_var_names=matmul_variadic_tpl.get_anchor_iter_var_names()
     )
     self._replace_with_load_from_register(
       mut_program,
@@ -276,7 +276,7 @@ class MatmulEpilogueFusion(abstract_drr.DrrPass):
     )
     print('after registry')
 
-    template_module = matmul_binary_tpl.MatmulBinaryTemplate(
+    template_module = matmul_variadic_tpl.MatmulVariadicTemplate(
       program_translator=program_translator,
       mut_kernel_arg_id_registry=mut_kernel_arg_id_registry,
     )


### PR DESCRIPTION
matmul_binary_tpl.py实际实现的是一个通用的适用于Variadic Epilogue融合的模板，故改名。