### PR TITLE
Add pass to handle dynamic gelu

### DIFF
--- a/tests/ap/op_compute_translator_util.py
+++ b/tests/ap/op_compute_translator_util.py
@@ -345,6 +345,31 @@ class PdOpTanhCodeGen:
       f"op{self.op_property.op_index}_out{i}"
     )
 
+class PdOpFloorCodeGen:
+  def __init__(self,
+               op_property,
+               input_properties,
+               output_properties,
+               kernel_arg_translator,
+               index_program_translator_map):
+    self.op_property = op_property
+    self.input_properties = input_properties
+    self.output_properties = output_properties
+    self.kernel_arg_translator = kernel_arg_translator
+    self.index_program_translator_map = index_program_translator_map
+
+  def __call__(self, inputs, mut_kernel_arg_id_registry, mut_lir_code_gen_ctx):
+    var_name = inputs[0].var_name
+    out = self.get_out_cg_val(0)
+    mut_lir_code_gen_ctx.let(out, f"floor({var_name})")
+    return [out]
+
+  def get_out_cg_val(self, i):
+    return code_gen_value_util.CodeGenValue(
+      self.output_properties[i].type,
+      f"op{self.op_property.op_index}_out{i}"
+    )
+
 class CinnOpScaleCodeGen:
   def __init__(self,
                op_property,
@@ -597,6 +622,7 @@ class OpComputeTranslatorFactory:
       ["pd_op.exp",                 PdOpExpCodeGen],
       ["pd_op.relu",                PdOpReluCodeGen],
       ["pd_op.tanh",                PdOpTanhCodeGen],
+      ["pd_op.floor",               PdOpFloorCodeGen],
       ["pd_op.erf",                 PdOpErfCodeGen],
       ["pd_op.elementwise_pow",     PdOpElementwisePowCodeGen],
       ["cinn_op.scale",             CinnOpScaleCodeGen],

--- a/tests/ap/op_convertion_drr_pass.py
+++ b/tests/ap/op_convertion_drr_pass.py
@@ -34,6 +34,23 @@ class PdOpTanhAccessTopoPass(access_topo_drr.DrrPass):
       [t.output]
     )
 
+@access_topo_drr.register_drr_pass("pd_op_floor", tag="default")
+class PdOpFloorAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.floor_op = o.ap_native_op("pd_op.floor")
+    o.floor_op(
+      [t.input],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.result_op = o.ap_native_op("pd_op.relu")
+    o.result_op(
+      [t.input],
+      [t.output]
+    )
+
 @access_topo_drr.register_drr_pass("pd_op_erf", tag="default")
 class PdOpErfAccessTopoPass(access_topo_drr.DrrPass):
 
@@ -245,5 +262,69 @@ class PdOpRightFullAddAccessTopoPass(access_topo_drr.DrrPass):
     o.result_op = o.ap_native_op("pd_op.relu")
     o.result_op(
       [t.input],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("full_generate_shape_expand_left_add", tag="default")
+class FullGenerateShapeExpandLeftAddAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.full = o.ap_native_op("pd_op.full")
+    o.full(
+      [],
+      [t.intermediate0]
+    )
+    o.generate_shape = o.ap_native_op("cinn_op.generate_shape")
+    o.generate_shape(
+      [t.input0],
+      [t.intermediate1]
+    )
+    o.expand = o.ap_native_op("pd_op.expand")
+    o.expand(
+      [t.intermediate0, t.intermediate1],
+      [t.expanded_input]
+    )
+    o.add = o.ap_native_op("pd_op.add")
+    o.add(
+      [t.expanded_input, t.input0],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.relu = o.ap_native_op("pd_op.relu")
+    o.relu(
+      [t.input0],
+      [t.output]
+    )
+
+@access_topo_drr.register_drr_pass("full_generate_shape_expand_right_add", tag="default")
+class FullGenerateShapeExpandRightAddAccessTopoPass(access_topo_drr.DrrPass):
+
+  def source_pattern(self, o, t):
+    o.full = o.ap_native_op("pd_op.full")
+    o.full(
+      [],
+      [t.intermediate0]
+    )
+    o.generate_shape = o.ap_native_op("cinn_op.generate_shape")
+    o.generate_shape(
+      [t.input0],
+      [t.intermediate1]
+    )
+    o.expand = o.ap_native_op("pd_op.expand")
+    o.expand(
+      [t.intermediate0, t.intermediate1],
+      [t.expanded_input]
+    )
+    o.add = o.ap_native_op("pd_op.add")
+    o.add(
+      [t.input0, t.expanded_input],
+      [t.output]
+    )
+
+  def result_pattern(self, o, t):
+    o.relu = o.ap_native_op("pd_op.relu")
+    o.relu(
+      [t.input0],
       [t.output]
     )


### PR DESCRIPTION
添加了一个新的过程，用于简化动态 gelu，由于此模板具有通用性，因此将其添加到 op_conversion 中。
此pass的本质是使完整的运算符能够成功简化。

`full` ->   `expand`  - --->    `add`    本质上是一元运算，所以化简为 `relu`
`input1`   ____________/